### PR TITLE
ci: rename Zvame to Ztt in workflow artifact paths

### DIFF
--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -44,12 +44,12 @@ jobs:
         id: build_files
         run: make pdf
 
-      - name: Upload Zvame PDF
+      - name: Upload Ztt PDF
         if: steps.build_files.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
-          name: Zvame-0.1-${{ env.SHORT_SHA }}.pdf
-          path: ${{ github.workspace }}/build/Zvame-0.1.pdf
+          name: Ztt-0.1-${{ env.SHORT_SHA }}.pdf
+          path: ${{ github.workspace }}/build/Ztt-0.1.pdf
           retention-days: 7
 
       - name: Create Release
@@ -63,6 +63,6 @@ jobs:
             This release was created by: ${{ github.event.sender.login }}
             Release Notes: ${{ github.event.inputs.release_notes }}
           files: |
-            ${{ github.workspace }}/build/Zvame-0.1.pdf
+            ${{ github.workspace }}/build/Ztt-0.1.pdf
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN }}

--- a/.github/workflows/merge-and-release.yml
+++ b/.github/workflows/merge-and-release.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   on-success:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     container:
       image: ghcr.io/riscv/riscv-docs-base-container-image:latest
 
@@ -33,12 +35,12 @@ jobs:
         id: build_files
         run: make pdf
 
-      - name: Upload Zvame PDF
+      - name: Upload Ztt PDF
         if: steps.build_files.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
-          name: Zvame-0.1-${{ env.SHORT_SHA }}.pdf
-          path: ${{ github.workspace }}/build/Zvame-0.1.pdf
+          name: Ztt-0.1-${{ env.SHORT_SHA }}.pdf
+          path: ${{ github.workspace }}/build/Ztt-0.1.pdf
 
       - name: Create Release
         uses: softprops/action-gh-release@v3.0.0
@@ -53,6 +55,6 @@ jobs:
           generate_release_notes: true
           body: |
             This release was created by: ${{ github.event.sender.login }}
-            Release of AME (Zvame) specification, built from commit ${{ env.SHORT_SHA }}, is now available.
+            Release of AME (Ztt) specification, built from commit ${{ env.SHORT_SHA }}, is now available.
           files: |
-            ${{ github.workspace }}/build/Zvame-0.1.pdf
+            ${{ github.workspace }}/build/Ztt-0.1.pdf


### PR DESCRIPTION
## Summary

Follow-up to #7 (Zvame→Ztt rename). The CI workflows still reference
`Zvame-0.1.pdf` but the Makefile now outputs `Ztt-0.1.pdf`.

## Changes

- `isa-build.yml`: update artifact name/path from `Zvame-0.1` to `Ztt-0.1`
- `merge-and-release.yml`: update artifact name/path and release body,
  add `permissions: contents: write` for release creation

## Test plan

- [ ] CI build passes and uploads `Ztt-0.1.pdf` artifact
- [ ] Release workflow creates release with correct PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)