### PR TITLE
docs: packed datatype semantics + pack/unpack instructions

### DIFF
--- a/src/datatypes.adoc
+++ b/src/datatypes.adoc
@@ -163,32 +163,35 @@ The rounding mode of an operation is determined by the datatype of the destinati
 
 
 
-=== Storage-only datatypes
+=== Packed datatypes
 
 A datatype whose size (bits 7:0) is greater than zero and less than
-`<<udb:doc:param:AME_UNIT_DATATYPE_SIZE,AME_UNIT_DATATYPE_SIZE>>` is called a *storage-only datatype*.
-Storage-only datatypes are used to pack data efficiently in memory and in M registers,
-but they cannot be used directly as operands in compute instructions.
+`<<udb:doc:param:AME_UNIT_DATATYPE_SIZE,AME_UNIT_DATATYPE_SIZE>>` is called a *packed datatype*.
 
-When an M register is programmed with a storage-only datatype, it holds data *packed*:
-a single register contains `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(dtype)` logical
-squares. For example, with `AME_UNIT_DATATYPE_SIZE` = 16 bits and an 8-bit storage type,
-`pack_factor` = 2: one M register holds two squares of 8-bit elements.
+The *Pack Factor* (`pack_factor`) of a datatype is the number of squares stored per M register:
 
-Attempting to use a storage-only M register as an operand in a compute instruction
-(any 1D or 2D operation) results in `amestatus.UN` being set and the instruction returning
-without writing any output register. This is the discovery mechanism for storage-only support:
-software can probe which storage-only datatypes an implementation supports by attempting
-`mconv.ew` and inspecting `amestatus.UN`.
+* For packed datatypes: `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(dtype)` (>= 2; equals the pack factor)
+* For all other datatypes: `pack_factor = 1`
 
-To use data loaded from a storage-only register, software must first convert it to a
-compute datatype (size >= `AME_UNIT_DATATYPE_SIZE`) using the
-`<<udb:doc:inst:mconv_ew,mconv.ew>>` instruction, which expands one packed storage-only
-M register into `pack_factor` compute-dtype M registers.
+For example, with `AME_UNIT_DATATYPE_SIZE` = 8 bits and an Int4 (4-bit) datatype,
+`pack_factor` = 2: one M register holds two Int4 squares.
 
-Standard storage-only datatypes include Int4 and Uint4 (when `AME_UNIT_DATATYPE_SIZE` > 4),
+Packed datatypes can be used directly as operands in compute instructions.
+When an instruction has multiple tensor operands, each operand must contain the same total
+number of squares: `N_sq = max(pack_factor)` across all tensor operands.
+Each operand's register span is sized to hold exactly `N_sq` squares.
+Accumulator operands are not subject to this rule — they always hold exactly one square.
+
+See <<operand-formation>> in the programming model for the complete rules and a worked example.
+
+If a packed datatype/operation combination is not supported by an implementation,
+`amestatus.UN` is set and the instruction returns without writing any output register.
+Software can probe compute support by attempting a compute instruction and
+inspecting `amestatus.UN`.
+
+Standard packed datatypes include Int4 and Uint4 (when `AME_UNIT_DATATYPE_SIZE` > 4),
 and Int8/Uint8 (when `AME_UNIT_DATATYPE_SIZE` > 8).
-Whether any given storage-only type is supported is implementation-defined.
+Whether any given packed type is supported is implementation-defined.
 
 === Discovery
 

--- a/src/datatypes.adoc
+++ b/src/datatypes.adoc
@@ -168,13 +168,18 @@ The rounding mode of an operation is determined by the datatype of the destinati
 A datatype whose size (bits 7:0) is greater than zero and less than
 `<<udb:doc:param:AME_UNIT_DATATYPE_SIZE,AME_UNIT_DATATYPE_SIZE>>` is called a *packed datatype*.
 
-The *Pack Factor* (`pack_factor`) of a datatype is the number of squares stored per M register:
+Whether any particular datatype is packed is entirely a function of the
+implementation-defined base element size `<<udb:doc:param:AME_UNIT_DATATYPE_SIZE,AME_UNIT_DATATYPE_SIZE>>`,
+so the same datatype may be packed on one implementation and non-packed on another.
+An implementation that sets `<<udb:doc:param:AME_UNIT_DATATYPE_SIZE,AME_UNIT_DATATYPE_SIZE>>`
+equal to its smallest supported element size has no packed datatypes at all; one that sets it
+larger treats every smaller supported datatype as packed.
+For this reason the specification does not designate any specific datatype as packed.
 
-* For packed datatypes: `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(dtype)` (>= 2; equals the pack factor)
+The *pack factor* (`pack_factor`) of a datatype is the number of squares stored per M register:
+
+* For packed datatypes: `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(dtype)` (always >= 2)
 * For all other datatypes: `pack_factor = 1`
-
-For example, with `AME_UNIT_DATATYPE_SIZE` = 8 bits and an Int4 (4-bit) datatype,
-`pack_factor` = 2: one M register holds two Int4 squares.
 
 Packed datatypes can be used directly as operands in compute instructions.
 When an instruction has multiple tensor operands, each operand must contain the same total
@@ -184,14 +189,17 @@ Accumulator operands are not subject to this rule — they always hold exactly o
 
 See <<operand-formation>> in the programming model for the complete rules and a worked example.
 
+Because a packed M register holds multiple squares, packed formats increase register
+pressure when combined with wide datatypes — for example, in kernels such as flash
+attention. Explicit pack/unpack instructions (see <<udb:doc:inst:mconv_ew,mconv.ew>>)
+therefore remain necessary to convert between packed and non-packed layouts and to manage
+that pressure.
+
 If a packed datatype/operation combination is not supported by an implementation,
 `amestatus.UN` is set and the instruction returns without writing any output register.
 Software can probe compute support by attempting a compute instruction and
-inspecting `amestatus.UN`.
-
-Standard packed datatypes include Int4 and Uint4 (when `AME_UNIT_DATATYPE_SIZE` > 4),
-and Int8/Uint8 (when `AME_UNIT_DATATYPE_SIZE` > 8).
-Whether any given packed type is supported is implementation-defined.
+inspecting `amestatus.UN`. Whether any given packed datatype is supported is
+implementation-defined.
 
 === Discovery
 

--- a/src/examples.adoc
+++ b/src/examples.adoc
@@ -26,9 +26,8 @@ For a given compute datatype with element size `dtype_bits`,
 The A-square group starts at `m0`; the B-square group starts at `m{group_size}`.
 All examples are restricted to `M 0–15` and `Acc0`, so group_size is at most 8.
 
-Storage-only datatypes (element size < `AME_UNIT_DATATYPE_SIZE`) cannot be used
-directly in compute instructions — they require `mconv.ew` expansion first — and
-are not covered in these examples.
+Packed datatypes (element size < `AME_UNIT_DATATYPE_SIZE`) can be used directly in
+compute instructions. These examples focus on non-packed datatypes for simplicity.
 
 The figure below illustrates the tiling for `M=K=P=4N`, showing a snapshot
 at `i_tile=1`, `k_tile=1`, `j_tile=2`.
@@ -230,7 +229,7 @@ Matrices are pre-formatted in the implementation-defined square layout, so `mls`
 Memory strides use `square_bytes = AME_NELEM × elem_bytes = 16384 × elem_bytes`.
 +
 `dtype` varies at runtime: `group_size = dtype_bits >> 3` (since `U = 8`).
-Storage-only datatypes (`dtype_bits < 8`) are rejected at entry.
+Packed datatypes (`dtype_bits < 8`) use `pack_factor > 1` and are handled separately.
 The triple loop is instantiated once per supported group_size via a macro.
 
 Algorithm::
@@ -244,9 +243,12 @@ int N          = 128;                    // t0: sqrt(16384)
 int dtype_bits = dtype & 0xFF;           // t2: element size in bits
 int elem_bytes = dtype_bits / 8;         // t3
 
-if (dtype_bits < 8) return;              // guard: reject storage-only datatypes
-
-int group_size    = dtype_bits / 8;      // t2: repurposed (U = 8 hardcoded)
+int group_size;
+if (dtype_bits < 8) {                   // packed datatype
+  group_size = 1;                        // pack_factor squares per register
+} else {
+  group_size = dtype_bits / 8;           // t2: repurposed (U = 8 hardcoded)
+}
 // A-sq group: m0…m[group_size-1]
 // B-sq group: m[group_size]…m[2*group_size-1]
 
@@ -312,14 +314,23 @@ gemm_square:
     andi   t2, a6, 0xFF           # t2 = dtype_bits
     srli   t3, t2, 3              # t3 = elem_bytes = dtype_bits / 8
 
-    # ── step 3: guard — reject storage-only datatypes ──────────────
+    # ── step 3: handle packed datatypes ────────────────────────────
     li     t1, 8
-    bltu   t2, t1, .done          # dtype_bits < 8 → unsupported
+    bltu   t2, t1, .packed_path    # dtype_bits < 8 → packed datatype
 
     # ── step 4: compute group_size ──────────────────────────────────
     # group_size = dtype_bits / U = dtype_bits / 8 (U = 8 is hardcoded)
     srli   t2, t2, 3              # t2 = group_size
+    j      .configure
 
+.packed_path:
+    # Packed datatypes use group_size = 1.
+    # elem_bytes for sub-byte types: use pack_factor to compute stride.
+    # pack_factor = U / dtype_bits; effective square_bytes = N * N * U / 8
+    li     t2, 1                   # t2 = group_size = 1
+    li     t3, 1                   # t3 = elem_bytes = U / 8 = 1 (stride unit)
+
+.configure:
     # ── step 5: configure datatypes ─────────────────────────────────
     msettyp m0, a6                # A-square group starts at m0
     msettyp acc0, a6
@@ -465,9 +476,12 @@ int U          = read_csr(ameudsz);    // t1: AME_UNIT_DATATYPE_SIZE in bits
 int dtype_bits = dtype & 0xFF;         // t2: element size in bits
 int elem_bytes = dtype_bits / 8;       // t3
 
-if (dtype_bits < U) return;            // guard: reject storage-only datatypes
-
-int group_size    = dtype_bits / U;    // t2: repurposed
+int group_size;
+if (dtype_bits < U) {                 // packed datatype
+  group_size = 1;
+} else {
+  group_size = dtype_bits / U;         // t2: repurposed
+}
 // A-tile group: m0…m[group_size-1]
 // B-tile group: m[group_size]…m[2*group_size-1]
 
@@ -534,10 +548,10 @@ gemm_portable:
     andi   t2, a6, 0xFF          # t2 = dtype_bits
     srli   t3, t2, 3             # t3 = elem_bytes = dtype_bits / 8
 
-    # ── step 3: guard — reject storage-only datatypes ──────────
-    # Storage-only types (dtype_bits < U) cannot be operands in compute
-    # instructions; they require mconv.ew expansion before use.
-    bltu   t2, t1, .done         # dtype_bits < U → unsupported
+    # ── step 3: handle packed datatypes ──────────────────────────
+    # Packed types (dtype_bits < U) use pack_factor squares per register.
+    # group_size is 1 for packed types.
+    bltu   t2, t1, .packed_port    # dtype_bits < U → packed datatype
 
     # ── step 4: compute group_size ─────────────────────────────
     # group_size = dtype_bits / U  (both are powers of 2)
@@ -545,7 +559,15 @@ gemm_portable:
     # group_size == 2 → two M registers per tile (dtype_bits == 2U)
     # etc.
     divu   t2, t2, t1            # t2 = group_size  (t1 = U now free)
+    j      .configure_port
 
+.packed_port:
+    # Packed datatypes use group_size = 1.
+    # elem_bytes for sub-byte types: use U/8 as the stride unit.
+    li     t2, 1                  # t2 = group_size = 1
+    srli   t3, t1, 3             # t3 = U / 8 (stride unit for packed)
+
+.configure_port:
     # ── step 5: configure datatypes ────────────────────────────
     msettyp m0, a6               # A-tile group starts at m0
     msettyp acc0, a6

--- a/src/functions.adoc
+++ b/src/functions.adoc
@@ -35,12 +35,12 @@ h| Arguments   l| AmeOperation op, Bits<8> dest_dtype, Bits<8> src1_dtype, Bits<
 return true;
 ----
 
-[#udb:doc:func:ame_dtype_is_storage_only]
-=== `ame_dtype_is_storage_only`
-Returns true if dtype_val is a storage-only datatype: its size in bits (bits 7:0) is
+[#udb:doc:func:ame_dtype_is_packed]
+=== `ame_dtype_is_packed`
+Returns true if dtype_val is a packed datatype: its size in bits (bits 7:0) is
 greater than zero and less than AME_UNIT_DATATYPE_SIZE.
-Storage-only datatypes are packed in M registers (pack_factor = AME_UNIT_DATATYPE_SIZE / size
-squares per register) and cannot be used as operands in compute instructions.
+Packed datatypes store pack_factor = AME_UNIT_DATATYPE_SIZE / size
+squares per register and can be used directly as operands in compute instructions.
 
 
 |===

--- a/src/images/ame-square-reg-mapping.svg
+++ b/src/images/ame-square-reg-mapping.svg
@@ -60,10 +60,10 @@
 
 
   <!-- ═══════════════════════════════════════════
-       CASE 3: PACKED STORAGE-ONLY
+       CASE 3: PACKED
        ═══════════════════════════════════════════ -->
 
-  <text x="698" y="20" text-anchor="middle" font-size="13" font-weight="bold" fill="#1e1e1e">Storage-only (packed)</text>
+  <text x="698" y="20" text-anchor="middle" font-size="13" font-weight="bold" fill="#1e1e1e">Packed</text>
 
   <!-- Register M[i] — two packed sub-squares side by side -->
   <text x="593" y="62" text-anchor="end" font-size="11" fill="#1e1e1e">M[i]</text>

--- a/src/instructions.adoc
+++ b/src/instructions.adoc
@@ -181,7 +181,7 @@ Register move / data conversion::
 | Mnemonic | Name
 
 a| `mconv.ew md, ms1`
-| <<udb:doc:inst:mconv_ew,Convert between storage-only and compute datatypes>>
+| <<udb:doc:inst:mconv_ew,Convert between packed and non-packed datatypes>>
 !===
 
 Log2 and Exp2::
@@ -435,8 +435,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ABS1D, dest_dtype, src1_dtype, 0)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -530,8 +528,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ABSDIFF1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -648,8 +644,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ABSDIFF1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -744,8 +738,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ADD1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -862,8 +854,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ADD1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -958,8 +948,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::AND1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -1076,8 +1064,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::AND1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -1174,8 +1160,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ANDNOT1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -1292,8 +1276,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ANDNOT1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -1366,8 +1348,8 @@ Description::
 Broadcasts the scalar value from integer register `xs1` to all element positions of
 matrix register `md`.
 +
-The element size is determined by `Md[md]`. For compute datatypes, all `AME_NELEM`
-elements are set to the lower `sizeof(Md[md])` bits of `xs1`. For storage-only datatypes,
+The element size is determined by `Md[md]`. For non-packed datatypes, all `AME_NELEM`
+elements are set to the lower `sizeof(Md[md])` bits of `xs1`. For packed datatypes,
 all `pack_factor * AME_NELEM` elements are set.
 +
 If `Md[md]` is uninitialized (zero), `amestatus.UN` is set and no register is written.
@@ -1400,7 +1382,7 @@ U32 element_size_bits = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_si
 if pass:[(]element_size_bits == 0) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
-  U32 pack_factor = <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dtype) ? (AME_UNIT_DATATYPE_SIZE / element_size_bits) : 1;
+  U32 pack_factor = <<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]dtype) ? (AME_UNIT_DATATYPE_SIZE / element_size_bits) : 1;
   U32 total_elements = pack_factor * AME_NELEM;
   Bits<AME_MAX_SQUARE_SIZE> result = 0;
   Bits<AME_MAX_DTYPE_SIZE> scalar = X[xs1];
@@ -1470,8 +1452,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MUXGE1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -1591,8 +1571,6 @@ Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MUX1D, dest_dtype, src1_dtype, src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -1708,8 +1686,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::CMPGE1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -1827,8 +1803,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::CMPGE1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -1930,8 +1904,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::CMPLT1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -2049,8 +2021,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::CMPLT1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -2151,8 +2121,6 @@ Operation::
 Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::COLUNZIP1D, dest_dtype, src1_dtype, src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -2262,8 +2230,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::COLZIP1D, dest_dtype, src1_dtype, src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -2324,7 +2290,7 @@ if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperati
 === `mconv.ew`
 
 Synopsis::
-Convert between storage-only and compute datatypes
+Convert between packed and non-packed datatypes
 
 Mnemonic::
 `mconv.ew md, ms1`
@@ -2340,26 +2306,26 @@ Encodings have not been allocated yet. This is just a placeholder.
 ....
 
 Description::
-Converts element data between a storage-only datatype and a compute datatype.
+Converts element data between a packed datatype and a non-packed datatype.
 +
 The source datatype is determined from `Md[ms1]` and the destination datatype from `Md[md]`.
-Exactly one of the two must be a storage-only datatype (size < `AME_UNIT_DATATYPE_SIZE`);
-if both or neither are storage-only, `mconv.1d` sets `amestatus.UN` and returns without
+Exactly one of the two must be a packed datatype (size < `AME_UNIT_DATATYPE_SIZE`);
+if both or neither are packed, `mconv.ew` sets `amestatus.UN` and returns without
 modifying any register.
 +
-**Expand (storage-only → compute):** When `Md[ms1]` is storage-only and `Md[md]` is a
-compute datatype, `ms1` holds `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`
-packed squares. `mconv.1d` converts each element from the storage datatype to the compute
+**Expand (packed → non-packed):** When `Md[ms1]` is packed and `Md[md]` is a
+non-packed datatype, `ms1` holds `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`
+packed squares. `mconv.ew` converts each element from the packed datatype to the non-packed
 datatype and writes `pack_factor` result squares to `md`, `md+1`, ..., `md+pack_factor-1`.
 The register index `md` must be a multiple of `pack_factor`; otherwise,
-`mconv.1d` raises an `Illegal Instruction` exception.
+`mconv.ew` raises an `Illegal Instruction` exception.
 +
-**Compress (compute → storage-only):** When `Md[ms1]` is a compute datatype and `Md[md]`
-is storage-only, `ms1`, `ms1+1`, ..., `ms1+pack_factor-1` each hold one compute-dtype square.
-`mconv.1d` converts each element from the compute datatype to the storage datatype and packs
+**Compress (non-packed → packed):** When `Md[ms1]` is a non-packed datatype and `Md[md]`
+is packed, `ms1`, `ms1+1`, ..., `ms1+pack_factor-1` each hold one non-packed square.
+`mconv.ew` converts each element from the non-packed datatype to the packed datatype and packs
 all `pack_factor` result squares into the single register `md`.
 The register index `ms1` must be a multiple of `pack_factor`; otherwise,
-`mconv.1d` raises an `Illegal Instruction` exception.
+`mconv.ew` raises an `Illegal Instruction` exception.
 +
 The specific element-level conversion (e.g., sign extension, truncation, rounding) is
 implementation-defined and discoverable via `amestatus.UN`.
@@ -2381,7 +2347,7 @@ Bits<32> src_dtype = Md[ms1];
 Bits<32> dst_dtype = Md[md];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::CONV1D, dst_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype) == <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dst_dtype)) {
+} else if pass:[(]<<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]src_dtype) == <<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]dst_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   if pass:[(]AME_NUM_M_REGS == 16) {
@@ -2389,7 +2355,7 @@ if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperati
       <<udb:doc:func:raise,raise>>pass:[(]ExceptionCode::IllegalInstruction, <<udb:doc:func:mode,mode>>pass:[(]), $encoding);
     }
   }
-  if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
+  if pass:[(]<<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]src_dtype)) {
     U32 src_element_size_bits = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
     U32 pack_factor = AME_UNIT_DATATYPE_SIZE / src_element_size_bits;
     U32 dst_element_size_bits = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]dst_dtype);
@@ -2488,8 +2454,6 @@ Operation::
 Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::EXP21D, dest_dtype, src1_dtype, src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -2591,8 +2555,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::GATHER1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -2751,8 +2713,6 @@ Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::HDIFF1D, dest_dtype, src1_dtype, src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -2868,8 +2828,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::HDIFF1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -2969,8 +2927,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::LDEXP1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -3093,8 +3049,6 @@ Bits<32> src_dtype = Md[ms2];
 Bits<32> exp_dtype = AME_MAX_INT_DTYPE;
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::LDEXP1D, dest_dtype, src_dtype, exp_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -3197,8 +3151,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::LDEXPACC1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -3325,8 +3277,6 @@ Bits<32> src_dtype = Md[ms2];
 Bits<32> exp_dtype = AME_MAX_INT_DTYPE;
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::LDEXPACC1D, dest_dtype, src_dtype, exp_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -3424,8 +3374,6 @@ Operation::
 Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::LOG21D, dest_dtype, src1_dtype, src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -3525,8 +3473,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::LOG2SUB1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -3646,8 +3592,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::LOG2SUB1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -3724,7 +3668,7 @@ The data in memory must have been previously stored in the implementation-define
 register format (e.g., by a matching `ss` instruction). No datatype conversion is
 performed; the in-memory layout is the exact register representation. All elements
 are loaded unconditionally. This instruction is correct for both compute and
-storage-only dtypes without any special handling.
+packed dtypes without any special handling.
 +
 For portable interoperability with other implementations, use
 `<%= link_to_udb_doc_inst("mls.rm") %>` or `<%= link_to_udb_doc_inst("mls.cm") %>`.
@@ -3785,7 +3729,7 @@ Description::
 Loads a square from memory in column-major format into matrix register `md`.
 +
 The datatype is determined from `Md[md]`. For compute datatypes
-(size >= `AME_UNIT_DATATYPE_SIZE`), one square is loaded. For storage-only datatypes
+(size >= `AME_UNIT_DATATYPE_SIZE`), one square is loaded. For packed datatypes
 (size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[md])`
 squares are loaded and packed into a single M register.
 +
@@ -3819,7 +3763,7 @@ if pass:[(]AME_NUM_M_REGS == 16) {
 }
 U32 element_size_bits = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]dtype);
 U32 element_size_bytes = element_size_bits >> 3;
-U32 pack_factor = <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dtype) ? (AME_UNIT_DATATYPE_SIZE / element_size_bits) : 1;
+U32 pack_factor = <<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]dtype) ? (AME_UNIT_DATATYPE_SIZE / element_size_bits) : 1;
 XReg total_bytes = pack_factor * AME_NELEM * element_size_bytes;
 XReg alignment = <<udb:doc:func:min,min>>pass:[(]total_bytes, 4096);
 if pass:[(]address % alignment != 0) {
@@ -3865,7 +3809,7 @@ Description::
 Loads a square from memory in row-major format into matrix register `md`.
 +
 The datatype is determined from `Md[md]`. For compute datatypes
-(size >= `AME_UNIT_DATATYPE_SIZE`), one square is loaded. For storage-only datatypes
+(size >= `AME_UNIT_DATATYPE_SIZE`), one square is loaded. For packed datatypes
 (size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[md])`
 squares are loaded and packed into a single M register.
 +
@@ -3899,7 +3843,7 @@ if pass:[(]AME_NUM_M_REGS == 16) {
 }
 U32 element_size_bits = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]dtype);
 U32 element_size_bytes = element_size_bits >> 3;
-U32 pack_factor = <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dtype) ? (AME_UNIT_DATATYPE_SIZE / element_size_bits) : 1;
+U32 pack_factor = <<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]dtype) ? (AME_UNIT_DATATYPE_SIZE / element_size_bits) : 1;
 XReg total_bytes = pack_factor * AME_NELEM * element_size_bytes;
 XReg alignment = <<udb:doc:func:min,min>>pass:[(]total_bytes, 4096);
 if pass:[(]address % alignment != 0) {
@@ -3968,8 +3912,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MAX1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -4086,8 +4028,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MAX1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -4183,8 +4123,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MEAN1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -4301,8 +4239,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MEAN1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -4398,8 +4334,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MIN1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -4515,8 +4449,6 @@ Operation::
 Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MIN1D, dest_dtype, src_dtype, src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
@@ -4786,8 +4718,6 @@ Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MM1D, dest_dtype, src1_dtype, src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -4888,8 +4818,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MUL1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -5006,8 +4934,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MUL1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -5110,8 +5036,6 @@ Bits<32> dest_dtype = Ad[acc];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MMACC1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -5221,8 +5145,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MULACC1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -5344,8 +5266,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MULACC1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -5449,8 +5369,6 @@ Bits<32> dest_dtype = Ad[acc];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MMACCNEG1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -5560,8 +5478,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MULNACC1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -5683,8 +5599,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MULNACC1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -5789,8 +5703,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MULADD1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -5912,8 +5824,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MULADD1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -6015,8 +5925,6 @@ Bits<32> dest_dtype = Ad[acc];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MMAT1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -6126,8 +6034,6 @@ Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MMATACC1D, dest_dtype, src1_dtype, src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -6233,8 +6139,6 @@ Bits<32> dest_dtype = Ad[acc];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MMBT1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -6344,8 +6248,6 @@ Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MMBTACC1D, dest_dtype, src1_dtype, src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -6452,8 +6354,6 @@ Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MMNEG1D, dest_dtype, src1_dtype, src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -6558,8 +6458,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::NMUL1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -6676,8 +6574,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::NMUL1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -6781,8 +6677,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MULSUB1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -6905,8 +6799,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::MULSUB1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -7003,8 +6895,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::OR1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -7121,8 +7011,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::OR1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -7219,8 +7107,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ORNOT1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -7337,8 +7223,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ORNOT1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -7440,8 +7324,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::PREFIXADDCOL1D, dest_dtype, src1_dtype, src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -7541,8 +7423,6 @@ Operation::
 Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::PREFIXADD1D, dest_dtype, src1_dtype, src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -7644,8 +7524,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::PREFIXMAXCOL1D, dest_dtype, src1_dtype, src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -7746,8 +7624,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::PREFIXMAX1D, dest_dtype, src1_dtype, src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -7846,8 +7722,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::RDEXP1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -7963,8 +7837,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::RDEXPACC1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -8082,8 +7954,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::REDUCEADDCOL1D, dest_dtype, src1_dtype, src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -8187,8 +8057,6 @@ Operation::
 Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::REDUCEADD1D, dest_dtype, src1_dtype, src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -8294,8 +8162,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::REDUCEMAXCOL1D, dest_dtype, src1_dtype, src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -8399,8 +8265,6 @@ Operation::
 Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::REDUCEMAX1D, dest_dtype, src1_dtype, src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -8507,8 +8371,6 @@ Operation::
 Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ROWUNZIP1D, dest_dtype, src1_dtype, src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -8633,8 +8495,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ROWZIP1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -8770,8 +8630,6 @@ Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::SCATADDCOL1D, dest_dtype, src1_dtype, src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -8897,8 +8755,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::SCATADD1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -9026,8 +8882,6 @@ Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::SCATMAXCOL1D, dest_dtype, src1_dtype, src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -9154,8 +9008,6 @@ Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::SCATMAX1D, dest_dtype, src1_dtype, src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -9276,8 +9128,6 @@ Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::SELGE1D, dest_dtype, src1_dtype, src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -9393,8 +9243,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::SEL1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -9570,8 +9418,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::SHIFT1D, dest_dtype, src1_dtype, src1_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
   U32 src1_nregs = src1_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -9652,7 +9498,7 @@ register format.
 The data written to memory is in the same implementation-defined format used by the
 matching load instruction (`ls`). No datatype conversion is performed. All elements
 are stored unconditionally. This instruction is correct for both compute and
-storage-only dtypes without any special handling.
+packed dtypes without any special handling.
 +
 For portable interoperability with other implementations, use
 `<%= link_to_udb_doc_inst("mss.rm") %>` or `<%= link_to_udb_doc_inst("mss.cm") %>`.
@@ -9713,7 +9559,7 @@ Description::
 Stores a square from matrix register `ms1` into memory in column-major format.
 +
 The datatype is determined from `Md[ms1]`. For compute datatypes
-(size >= `AME_UNIT_DATATYPE_SIZE`), one square is stored. For storage-only datatypes
+(size >= `AME_UNIT_DATATYPE_SIZE`), one square is stored. For packed datatypes
 (size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`
 squares are unpacked from the single M register and stored.
 +
@@ -9747,7 +9593,7 @@ if pass:[(]AME_NUM_M_REGS == 16) {
 }
 U32 element_size_bits = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]dtype);
 U32 element_size_bytes = element_size_bits >> 3;
-U32 pack_factor = <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dtype) ? (AME_UNIT_DATATYPE_SIZE / element_size_bits) : 1;
+U32 pack_factor = <<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]dtype) ? (AME_UNIT_DATATYPE_SIZE / element_size_bits) : 1;
 XReg total_bytes = pack_factor * AME_NELEM * element_size_bytes;
 XReg alignment = <<udb:doc:func:min,min>>pass:[(]total_bytes, 4096);
 if pass:[(]address % alignment != 0) {
@@ -9792,7 +9638,7 @@ Description::
 Stores a square from matrix register `ms1` into memory in row-major format.
 +
 The datatype is determined from `Md[ms1]`. For compute datatypes
-(size >= `AME_UNIT_DATATYPE_SIZE`), one square is stored. For storage-only datatypes
+(size >= `AME_UNIT_DATATYPE_SIZE`), one square is stored. For packed datatypes
 (size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`
 squares are unpacked from the single M register and stored.
 +
@@ -9826,7 +9672,7 @@ if pass:[(]AME_NUM_M_REGS == 16) {
 }
 U32 element_size_bits = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]dtype);
 U32 element_size_bytes = element_size_bits >> 3;
-U32 pack_factor = <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dtype) ? (AME_UNIT_DATATYPE_SIZE / element_size_bits) : 1;
+U32 pack_factor = <<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]dtype) ? (AME_UNIT_DATATYPE_SIZE / element_size_bits) : 1;
 XReg total_bytes = pack_factor * AME_NELEM * element_size_bytes;
 XReg alignment = <<udb:doc:func:min,min>>pass:[(]total_bytes, 4096);
 if pass:[(]address % alignment != 0) {
@@ -9893,8 +9739,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::SUB1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -10011,8 +9855,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::SUB1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -10113,8 +9955,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::SUBLOG21D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -10234,8 +10074,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::SUBLOG21D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -10330,8 +10168,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src1_dtype = Md[ms1];
 Bits<32> src2_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::XOR1D, dest_dtype, src1_dtype, src2_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src1_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src2_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src1_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src1_dtype);
@@ -10448,8 +10284,6 @@ Bits<32> dest_dtype = Md[md];
 Bits<32> src_dtype = Md[ms2];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::XOR1D, dest_dtype, src_dtype, src_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype) || <<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]src_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 src_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
   U32 src_nregs = src_element_size / AME_UNIT_DATATYPE_SIZE;
@@ -10542,8 +10376,6 @@ Operation::
 ----
 Bits<32> dest_dtype = Ad[acc];
 if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::ZERO1D, dest_dtype, dest_dtype, dest_dtype)) {
-  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
-} else if pass:[(]<<udb:doc:func:ame_dtype_is_storage_only,ame_dtype_is_storage_only>>pass:[(]dest_dtype)) {
   CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
 } else {
   U32 dest_element_size = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]dest_dtype);

--- a/src/instructions.adoc
+++ b/src/instructions.adoc
@@ -6,7 +6,7 @@
 
 
 
-AME defines *98* instructions and an additional *2* pseudoinstructions.
+AME defines *100* instructions and an additional *2* pseudoinstructions.
 
 
 Datatype Management::
@@ -169,10 +169,10 @@ a| `mscatmax.row md, ms1, ms2`
 | <<udb:doc:inst:mscatmax_row,Elementwise scatter-max>>
 a| `mshift.ew md, ms1, imm`
 | <<udb:doc:inst:mshift_ew,Elementwise row shift by constant offset>>
-a| `mshift.p1 md, ms1`
-| _Alias for_ <<udb:doc:inst:mshift_ew,mshift.ew>> _when_ `imm == 1`
 a| `mshift.m1 md, ms1`
 | _Alias for_ <<udb:doc:inst:mshift_ew,mshift.ew>> _when_ `imm == -1`
+a| `mshift.p1 md, ms1`
+| _Alias for_ <<udb:doc:inst:mshift_ew,mshift.ew>> _when_ `imm == 1`
 !===
 
 Register move / data conversion::
@@ -182,6 +182,10 @@ Register move / data conversion::
 
 a| `mconv.ew md, ms1`
 | <<udb:doc:inst:mconv_ew,Convert between packed and non-packed datatypes>>
+a| `mpack.ew.x md, ms1, xs1`
+| <<udb:doc:inst:mpack_ew_x,Pack one square into a slot of a packed M register>>
+a| `munpack.ew.x md, ms1, xs1`
+| <<udb:doc:inst:munpack_ew_x,Unpack one sub-square from a packed M register>>
 !===
 
 Log2 and Exp2::
@@ -7272,6 +7276,95 @@ if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperati
 
 <<<
 
+[#udb:doc:inst:mpack_ew_x]
+=== `mpack.ew.x`
+
+Synopsis::
+Pack one square into a slot of a packed M register
+
+Mnemonic::
+`mpack.ew.x md, ms1, xs1`
+
+Encoding::
++
+[IMPORTANT]
+Encodings have not been allocated yet. This is just a placeholder.
++
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2b,"type":2},{"bits":5,"name": "md","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "ms1","type":4},{"bits":5,"name": "xs1","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Inserts the single non-packed square in `ms1` into the sub-square slot selected by the
+index in integer register `xs1` of the packed M register `md`, converting each element
+from the non-packed datatype (`Md[ms1]`) to the packed datatype (`Md[md]`). The other
+sub-square slots of `md` are preserved (read-modify-write).
++
+`Md[md]` must be a packed datatype and `Md[ms1]` a non-packed datatype; otherwise
+`amestatus.UN` is set and no register is written. The index must be less than
+`pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[md])`; an out-of-range index raises an
+`Illegal Instruction` exception.
++
+This is the single-square form of the pack (compress) direction of
+<<udb:doc:inst:mconv_ew,mconv.ew>>; use it to pack one square at a time without holding
+all `pack_factor` non-packed squares in registers simultaneously.
+
+
+NumPy Equivalent::
+[source,python]
+----
+md[xs1] = pack(ms1)  # one sub-square, others preserved
+----
+
+Decode Variables::
+[source,idl,subs="specialchars,macros"]
+----
+Bits<5> md = $encoding[11:7];
+Bits<5> ms1 = $encoding[19:15];
+Bits<5> xs1 = $encoding[24:20];
+----
+
+
+Operation::
+[source,idl,subs="specialchars,macros"]
+----
+Bits<32> src_dtype = Md[ms1];
+Bits<32> dst_dtype = Md[md];
+U32 index = X[xs1];
+if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::CONV1D, dst_dtype, src_dtype, src_dtype)) {
+  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
+} else if pass:[(]<<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]src_dtype) || !<<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]dst_dtype)) {
+  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
+} else {
+  if pass:[(]AME_NUM_M_REGS == 16) {
+    if pass:[(]ms1 >= 16 || md >= 16) {
+      <<udb:doc:func:raise,raise>>pass:[(]ExceptionCode::IllegalInstruction, <<udb:doc:func:mode,mode>>pass:[(]), $encoding);
+    }
+  }
+  U32 dst_element_size_bits = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]dst_dtype);
+  U32 pack_factor = AME_UNIT_DATATYPE_SIZE / dst_element_size_bits;
+  if pass:[(]index >= pack_factor) {
+    <<udb:doc:func:raise,raise>>pass:[(]ExceptionCode::IllegalInstruction, <<udb:doc:func:mode,mode>>pass:[(]), $encoding);
+  }
+  U32 src_element_size_bits = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
+  Bits<AME_MAX_SQUARE_SIZE> packed = <<udb:doc:func:ame_xform_impl_to_rm,ame_xform_impl_to_rm>>pass:[(]M[md], dst_dtype);
+  Bits<AME_MAX_SQUARE_SIZE> src_data = <<udb:doc:func:ame_xform_impl_to_rm,ame_xform_impl_to_rm>>pass:[(]M[ms1], src_dtype);
+  for pass:[(]U32 e = 0; e < AME_NELEM; e++) {
+    U32 src_lo = e * src_element_size_bits;
+    U32 src_hi = src_lo pass:[+] src_element_size_bits - 1;
+    Bits<AME_MAX_DTYPE_SIZE> element = src_data[src_hi:src_lo];
+    U32 dst_lo = (index * AME_NELEM pass:[+] e) * dst_element_size_bits;
+    U32 dst_hi = dst_lo pass:[+] dst_element_size_bits - 1;
+    packed[dst_hi:dst_lo] = <<udb:doc:func:ame_op,ame_op>>pass:[(]AmeOperation::CONV1D, src_dtype, element, src_dtype, element, dst_dtype);
+  }
+  M[md] = <<udb:doc:func:ame_xform_rm_to_impl,ame_xform_rm_to_impl>>pass:[(]packed, dst_dtype);
+}
+----
+
+
+<<<
+
 [#udb:doc:inst:mprefixadd_col]
 === `mprefixadd.col`
 
@@ -10117,6 +10210,94 @@ if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperati
     result = <<udb:doc:func:ame_op,ame_op>>pass:[(]AmeOperation::SUBLOG21D, src_dtype, src_element_value, src_dtype, scalar_element_value, dest_dtype);
   }
   M[md pass:[+] dest_regno] = <<udb:doc:func:ame_xform_rm_to_impl,ame_xform_rm_to_impl>>pass:[(]result, dest_dtype);
+}
+----
+
+
+<<<
+
+[#udb:doc:inst:munpack_ew_x]
+=== `munpack.ew.x`
+
+Synopsis::
+Unpack one sub-square from a packed M register
+
+Mnemonic::
+`munpack.ew.x md, ms1, xs1`
+
+Encoding::
++
+[IMPORTANT]
+Encodings have not been allocated yet. This is just a placeholder.
++
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2b,"type":2},{"bits":5,"name": "md","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "ms1","type":4},{"bits":5,"name": "xs1","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Extracts a single sub-square, selected by the index in integer register `xs1`, from the
+packed M register `ms1` and writes it to the non-packed M register `md`, converting each
+element from the packed datatype (`Md[ms1]`) to the non-packed datatype (`Md[md]`).
++
+`Md[ms1]` must be a packed datatype and `Md[md]` a non-packed datatype; otherwise
+`amestatus.UN` is set and no register is written. The index must be less than
+`pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`; an out-of-range index raises an
+`Illegal Instruction` exception.
++
+This is the single-square form of the unpack (expand) direction of
+<<udb:doc:inst:mconv_ew,mconv.ew>>; use it to unpack one square at a time and limit the
+register pressure of fully expanding a packed register.
+
+
+NumPy Equivalent::
+[source,python]
+----
+md = unpack(ms1)[xs1]  # one sub-square
+----
+
+Decode Variables::
+[source,idl,subs="specialchars,macros"]
+----
+Bits<5> md = $encoding[11:7];
+Bits<5> ms1 = $encoding[19:15];
+Bits<5> xs1 = $encoding[24:20];
+----
+
+
+Operation::
+[source,idl,subs="specialchars,macros"]
+----
+Bits<32> src_dtype = Md[ms1];
+Bits<32> dst_dtype = Md[md];
+U32 index = X[xs1];
+if pass:[(]!<<udb:doc:func:ame_op_supported,ame_op_supported>>pass:[(]AmeOperation::CONV1D, dst_dtype, src_dtype, src_dtype)) {
+  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
+} else if pass:[(]!<<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]src_dtype) || <<udb:doc:func:ame_dtype_is_packed,ame_dtype_is_packed>>pass:[(]dst_dtype)) {
+  CSR[<<udb:doc:csr:amestatus,amestatus>>].<<udb:doc:csr_field:amestatus:UN,UN>> = 1;
+} else {
+  if pass:[(]AME_NUM_M_REGS == 16) {
+    if pass:[(]ms1 >= 16 || md >= 16) {
+      <<udb:doc:func:raise,raise>>pass:[(]ExceptionCode::IllegalInstruction, <<udb:doc:func:mode,mode>>pass:[(]), $encoding);
+    }
+  }
+  U32 src_element_size_bits = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]src_dtype);
+  U32 pack_factor = AME_UNIT_DATATYPE_SIZE / src_element_size_bits;
+  if pass:[(]index >= pack_factor) {
+    <<udb:doc:func:raise,raise>>pass:[(]ExceptionCode::IllegalInstruction, <<udb:doc:func:mode,mode>>pass:[(]), $encoding);
+  }
+  U32 dst_element_size_bits = <<udb:doc:func:ame_dtype_val_to_size,ame_dtype_val_to_size>>pass:[(]dst_dtype);
+  Bits<AME_MAX_SQUARE_SIZE> packed = <<udb:doc:func:ame_xform_impl_to_rm,ame_xform_impl_to_rm>>pass:[(]M[ms1], src_dtype);
+  Bits<AME_MAX_SQUARE_SIZE> result = 0;
+  for pass:[(]U32 e = 0; e < AME_NELEM; e++) {
+    U32 src_lo = (index * AME_NELEM pass:[+] e) * src_element_size_bits;
+    U32 src_hi = src_lo pass:[+] src_element_size_bits - 1;
+    Bits<AME_MAX_DTYPE_SIZE> element = packed[src_hi:src_lo];
+    U32 dst_lo = e * dst_element_size_bits;
+    U32 dst_hi = dst_lo pass:[+] dst_element_size_bits - 1;
+    result[dst_hi:dst_lo] = <<udb:doc:func:ame_op,ame_op>>pass:[(]AmeOperation::CONV1D, src_dtype, element, src_dtype, element, dst_dtype);
+  }
+  M[md] = <<udb:doc:func:ame_xform_rm_to_impl,ame_xform_rm_to_impl>>pass:[(]result, dst_dtype);
 }
 ----
 

--- a/src/programming_model.adoc
+++ b/src/programming_model.adoc
@@ -34,16 +34,27 @@ In contrast, an `Acc` register always holds exactly one square.
 
 === Squares
 
-All AME computational instructions operate on fixed-sized NxN square matrices.
+The *pack_factor* of a datatype is the number of squares contained in a single M register:
+
+* **Packed** (`sizeof(dtype) < AME_UNIT_DATATYPE_SIZE`): `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(dtype)`
+* **Unit or Wide** (`sizeof(dtype) >= AME_UNIT_DATATYPE_SIZE`): `pack_factor = 1`
+
+When the programmed datatype is a *packed datatype*
+(size < `<<udb:doc:param:AME_UNIT_DATATYPE_SIZE,AME_UNIT_DATATYPE_SIZE>>`),
+a single M register holds `pack_factor` logical squares.
+
+The number of elements processed by an AME matrix multiply instruction depends on the datatype.
+For non-packed datatypes (`pack_factor = 1`), the operands are `N x N` squares.
+For packed datatypes (`pack_factor > 1`), the input operands span `N x (pack_factor * N)` and `(pack_factor * N) x N`
+elements respectively, while the accumulator output remains `N x N`.
 
 [NOTE]
 --
-This constraint keeps the ISA and hardware simple: every compute instruction consumes and produces
-the same logical shape (`N x N`), so instruction encoding does not need per-operand shape fields,
-register mapping is uniform, and implementations can use fixed datapaths and scheduling.
+This constraint keeps the ISA simple: instruction encoding does not need per-operand shape fields
+and register mapping is uniform. The accumulator operand always holds exactly one `N x N` square.
 
 For contrast, general matrix multiply on non-square inputs (`M x K` by `K x N`) produces `M x N`.
-AME handles this by tiling into `N x N` squares and zero-padding boundary tiles in software.
+AME handles this by tiling into squares and zero-padding boundary tiles in software.
 
 .Example (`N = 8`)
 * Multiply `A(3x5)` by `B(5x2)`.
@@ -96,14 +107,8 @@ Specifying a register index that is not a multiple of the group size results in 
 Illegal Instruction exception.
 This mechanism is analogous to the `LMUL` facility used in the RISC-V vector (`V`) extension.
 
-When the programmed datatype is a *storage-only datatype*
-(size < `<<udb:doc:param:AME_UNIT_DATATYPE_SIZE,AME_UNIT_DATATYPE_SIZE>>`),
-multiple logical squares are packed into a single M register.
-The number of squares per register is the *pack factor*:
-`pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(dtype)`.
-Storage-only registers cannot be used as operands in compute instructions;
-`<<udb:doc:inst:mconv_ew,mconv.ew>>` must first expand the data into
-compute-dtype registers before computation.
+Packed datatypes can be used directly as operands in compute instructions;
+see <<operand-formation>> for how multi-operand instructions determine register spans.
 
 .Square-to-M-register mapping examples
 image::ame-square-reg-mapping.svg[Square to M register mapping examples]
@@ -122,6 +127,44 @@ madd.1d m2, m2, m2  # well-defined, m2 = m2 + m2
 madd.1d m2, m3, m3  # undefined
 madd.1d m3, m2, m2  # undefined
 ----
+
+[[operand-formation]]
+==== Operand formation
+
+When a compute instruction references multiple tensor operands, all operands must contain
+the same total number of squares.
+The instruction's square count is `N_sq = max(pack_factor)` across all tensor operands.
+
+Each operand's register span is then sized to hold exactly `N_sq` squares:
+
+* **Packed operand** (`pack_factor > 1`): `N_sq / pack_factor` registers
+* **Unit or Wide operand** (`pack_factor = 1`): `N_sq x ceil(sizeof(dtype) / AME_UNIT_DATATYPE_SIZE)` registers
+
+
+Consider an ADD instruction with three tensor operands of different datatypes:
+
+.Operand formation example (`AME_UNIT_DATATYPE_SIZE` = 8 bits)
+[cols="1,1,1,1,1",options="header"]
+|===
+| Operand | Dtype | pack_factor | Register Span | Total Squares
+
+| Tsrc0 | Int4  | 2 | N_sq / 2 = 1 register  | 2
+| Tsrc1 | Int8  | 1 | N_sq x 1 = 2 registers | 2
+| Tdst  | Int16 | 1 | N_sq x 2 = 4 registers | 2
+|===
+
+`N_sq = max(2, 1, 1) = 2` (set by the Int4 operand with `pack_factor = 2`).
+All three operands contain `N_sq x AME_NELEM = 2 x AME_NELEM` elements total.
+
+Accumulator (`Acc`) operands are not subject to this rule:
+they always hold exactly one square regardless of datatype.
+
+This rule applies uniformly to both 1D (element-wise) and 2D (matrix multiply) instructions.
+For 1D instructions, each operand processes `N_sq` squares element-wise — a packed
+operand's `pack_factor` squares are stored contiguously in a single register, while a
+non-packed operand's `N_sq` squares span `N_sq` registers.
+For 2D matrix multiply instructions, the inner product dimension extends to
+`pack_factor * N` elements; see <<_2_dimensional_matrix_multiply_operations>>.
 
 === Polymorphic instructions
 
@@ -160,14 +203,6 @@ Profiles will likely mandate a minimal set of supported datatypes.
 
 Datatypes are set using the <<udb:doc:inst:msettyp,msettyp>> instruction and
 read using the <<udb:doc:inst:mgettyp,mgettyp>> instruction.
-
-==== Compute and storage datatypes
-
-For a given implementation, datatypes can be partitioned into *compute* datatypes and *storage*
-datatypes. Compute datatypes are those that can be used with AME 1D and/or 2D computation instructions.
-Storage datatypes are those that can _only_ be used as the destination or source of a load or store.
-Any datatype whose size is less than <<udb:doc:param:AME_UNIT_DATATYPE_SIZE,AME_UNIT_DATATYPE_SIZE>> _must_ be a storage datatype.
-Storage datatypes are useful to handle packed datatype formats; see <<mapping-squares-to-m-registers>> for more details.
 
 === Data movement
 
@@ -230,14 +265,17 @@ AME does not support general masking/predication on computational instructions, 
 
 ==== 2-dimensional matrix multiply operations
 
-Full N^3^ matrix multiplication of squares is a primitive operation of AME, performed using a single instruction.
+AME matrix multiplication instructions calculate the matrix product `C = A x B`.
 
-AME matrix multiplication instructions calculate the matrix product, `C` of two squares, `A` and `B`.
+For *non-packed datatypes* (`pack_factor = 1`), A and B are each a single `N x N` square.
+For *packed datatypes* (`pack_factor > 1`), A is an `N x (pack_factor * N)` matrix (pack_factor squares laid side-by-side
+in the column dimension) and B is an `(pack_factor * N) x N` matrix (pack_factor squares stacked in the row
+dimension). The accumulator output C is always `N x N` regardless of `pack_factor`.
 
 Each output element `C[i,j]` is computed as the dot product of:
 
-* row `i` of `A`, and
-* column `j` of `B`.
+* row `i` of `A` (length `pack_factor * N`), and
+* column `j` of `B` (length `pack_factor * N`).
 
 The accumulation order for additions inside each dot product is implementation-defined.
 That order is fixed within a given implementation, so repeated runs on the same implementation
@@ -254,9 +292,13 @@ Formally:
 --
 def perm(range): implementation-defined permutation over range
 
+# K = N     for non-packed datatypes (pack_factor = 1)
+# K = pack_factor*N  for packed datatypes     (pack_factor > 1)
+K = pack_factor * N
+
 for i from 0 to N-1:
   for j from 0 to N-1:
-    C[i,j] = sum(A[i,k] * B[k,j] for k in perm(0..N-1))
+    C[i,j] = sum(A[i,k] * B[k,j] for k in perm(0..K-1))
 --
 
 Matrix multiplication is not commutative (`A*B != B*A` in general),
@@ -603,8 +645,8 @@ typically used to initialize an accumulator before a matrix multiply sequence.
 |===
 
 `<<udb:doc:inst:mconv_ew,mconv.ew>>` converts element data from one datatype to another.
-An expand converts a single packed `M` register (storage-only dtype) into `pack_factor` consecutive
-compute-dtype `M` registers; a compress does the reverse.
+An expand converts a single packed `M` register (packed dtype) into `pack_factor` consecutive
+non-packed `M` registers; a compress does the reverse.
 
 ==== Scalars
 
@@ -621,7 +663,7 @@ With `Ztts`, elementwise add by a common constant is a single instruction.
 
 AME provides two instructions to fill every element of an M register with a single scalar value,
 analogous to `np.full_like`. The element size is determined by the register's programmed datatype.
-Both compute and storage-only dtypes are supported; for storage-only dtypes all
+Both non-packed and packed dtypes are supported; for packed dtypes all
 `pack_factor * AME_NELEM` element positions are filled.
 
 `<<udb:doc:inst:mbcast_x,mbcast.x>>` sources the scalar from an integer (`X`) register.
@@ -653,50 +695,29 @@ or is pre-determined (for example, a constant exponent operand is always an XLEN
 ==== Load and store
 
 The row-major and column-major interoperability instructions (`mls.rm`, `mls.cm`, `mss.rm`, `mss.cm`)
-support both compute and storage-only datatypes. Data is always transferred as a single
+support both non-packed and packed datatypes. Data is always transferred as a single
 contiguous block — no striding, partial-tile, or predicated variants exist.
 
-For *compute datatypes* (size >= `AME_UNIT_DATATYPE_SIZE`), one square is transferred
+For *non-packed datatypes* (size >= `AME_UNIT_DATATYPE_SIZE`), one square is transferred
 between memory and one (or more, for wide types) M registers.
 
-For *storage datatypes* (size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor` squares are
+For *packed datatypes* (size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor` squares are
 transferred in a single instruction:
 
-* **Load:** `pack_factor` squares are loaded from contiguous memory and packed into a single
-  M register. In row-major format, sub-square `sq` occupies the `sq`-th block of
-  `sqrt(AME_NELEM)` rows in memory. In column-major format, sub-square `sq` occupies the
-  `sq`-th block of `sqrt(AME_NELEM)` columns.
+* **Load:** `pack_factor` squares are loaded from contiguous memory and packed into a
+  single M register. Each sub-square contains `AME_NELEM` elements.
+  In row-major format, the load accesses `sqrt(AME_NELEM)` rows and
+  `pack_factor * sqrt(AME_NELEM)` columns in memory, where sub-square `sq` occupies columns
+  `sq * sqrt(AME_NELEM)` to `(sq+1) * sqrt(AME_NELEM) - 1`.
+  In column-major format, the load accesses `pack_factor * sqrt(AME_NELEM)` rows and
+  `sqrt(AME_NELEM)` columns in memory, where sub-square `sq` occupies rows
+  `sq * sqrt(AME_NELEM)` to `(sq+1) * sqrt(AME_NELEM) - 1`.
 
 * **Store:** The single packed M register is unpacked and `pack_factor` squares are written
   to contiguous memory using the same layout.
 
-The typical workflow for storage-only data is:
-
-// not really bash, but it gets us colored # comments
-[source,bash]
-----
-  # Load INT4 data (pack_factor = AME_UNIT_DATATYPE_SIZE / 4 squares per register)
-  li t0, INT4_DTYPE
-  msettyp m0, t0
-  mls.rm m0, a0                  # loads pack_factor INT4 squares into m0
-
-  # Expand INT4 → INT16 before compute
-  li t0, INT16_DTYPE
-  msettyp m4, t0                # m4, m5, ... will hold the expanded squares
-  mconv.ew m4, m0               # expands m0 into m4..m(4+pack_factor-1)
-
-  # Compute using m4..m(4+pack_factor-1) as normal INT16 registers
-  madd.1d m8, m4, m4
-
-  # Optionally compress back to INT4 for storage
-  li t0, INT4_DTYPE
-  msettyp m0, t0
-  mconv.ew m0, m8               # compresses m8..m(8+pack_factor-1) → m0
-  mss.rm m0, a3                  # stores pack_factor INT4 squares from m0
-----
-
 The opaque-format instructions (`mls`, `mss`) transfer the raw M register contents without
-interpreting the datatype and are correct for both compute and storage-only dtypes.
+interpreting the datatype and are correct for both non-packed and packed dtypes.
 
 AME includes a mix of precise and imprecise exceptions.
 When exceptions can occur, the precision is indicated. QQQ – more needed.

--- a/src/state.adoc
+++ b/src/state.adoc
@@ -136,9 +136,9 @@ This is analogous to reading `vlenb` in RISC-V Vector code.
 | Field | Location | Description
 
 | VALUE
-| `* 31:0 when CSR[mstatus].UXL == 0
-* 63:0 when CSR[mstatus].UXL == 1
-`
+a|
+* `31:0` when `CSR[mstatus].UXL == 0`
+* `63:0` when `CSR[mstatus].UXL == 1`
 | Tile side length (N)
 
 |===
@@ -168,9 +168,9 @@ without hardcoding any implementation-specific constant.
 | Field | Location | Description
 
 | VALUE
-| `* 31:0 when CSR[mstatus].UXL == 0
-* 63:0 when CSR[mstatus].UXL == 1
-`
+a|
+* `31:0` when `CSR[mstatus].UXL == 0`
+* `63:0` when `CSR[mstatus].UXL == 1`
 | Unit datatype size (AME_UNIT_DATATYPE_SIZE) in bits
 
 |===


### PR DESCRIPTION
## Summary

Update the AME packed-datatype semantics (formerly "storage-only"), address
reviewer feedback, and add single-square pack/unpack instructions.

## Changes

### Packed datatype semantics
- Rename "storage-only" → "packed" across the spec; packed datatypes can be
  used directly as operands in compute instructions.
- Rename `ame_dtype_is_storage_only` → `ame_dtype_is_packed`; remove the
  storage-only guard from the elementwise instruction pseudocode.
- Add the operand-formation rules (`N_sq = max(pack_factor)`) and update the
  2D matmul description for the packed inner dimension.

### Reviewer feedback (Luca)
- **Packed-ness is implementation-relative.** Removed the specific
  Int4/Uint4/Int8/Uint8 examples. Whether a datatype is packed depends
  entirely on the implementation-defined base element size
  `AME_UNIT_DATATYPE_SIZE`: an implementation that sets the base to its
  smallest supported size has no packed datatypes, while one that sets it
  larger treats every smaller datatype as packed. The spec no longer
  designates any specific datatype as packed.
- **Pack/unpack instructions are still needed.** Noted that packed formats
  increase register pressure when combined with wide datatypes (e.g. flash
  attention); `mconv.ew` is retained as the whole-register pack/unpack.

### New instructions
- `munpack.ew.x md, ms1, xs1` — extract the sub-square selected by `X[xs1]`
  from packed `ms1` into non-packed `md`.
- `mpack.ew.x md, ms1, xs1` — insert non-packed `ms1` into the slot selected
  by `X[xs1]` of packed `md` (read-modify-write; other slots preserved).

These single-square variants let software pack/unpack one sub-square at a time
without materialising all `pack_factor` non-packed squares simultaneously,
directly addressing the register-pressure concern. Out-of-range index raises
Illegal Instruction; a wrong packed/non-packed pairing sets `amestatus.UN`.
Instruction count 98 → 100.

## Deferred (separate proposal)
Reviewer suggestion to bake up-convert into the load/store path (so an
implementation need not support sub-base datatypes) introduces new
load/store-with-conversion semantics and will be brought as a separate
proposal for TG discussion.

## Test plan
- [x] `make pdf` succeeds, zero warnings/errors
- [x] All cross-references resolve; body/tables remain alphabetical
- [x] pre-commit clean (no tabs / trailing whitespace / missing EOF newline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)