### PR TITLE
Define AME enablement and shared-backend ownership

### DIFF
--- a/INSTRUCTION_ENCODINGS.html
+++ b/INSTRUCTION_ENCODINGS.html
@@ -11,7 +11,7 @@
       font:14px/1.45 system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
     main { max-width:1800px; margin:auto; padding:28px; } h1 { margin:0 0 6px; font-size:28px; }
     h2 { margin:30px 0 12px; } p { color:var(--muted); } code { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; }
-    .cards { display:grid; grid-template-columns:repeat(5,minmax(130px,1fr)); gap:12px; margin:20px 0; }
+    .cards { display:grid; grid-template-columns:repeat(6,minmax(130px,1fr)); gap:12px; margin:20px 0; }
     .card { background:var(--paper); border:1px solid var(--line); border-radius:10px; padding:14px 16px; }
     .card strong { display:block; font-size:24px; } .card span { color:var(--muted); }
     .formats { display:grid; gap:10px; } .format-row { display:grid; grid-template-columns:54px 1fr; align-items:center;
@@ -27,6 +27,7 @@
     .num { color:var(--muted); text-align:right; } .synopsis { color:var(--muted); font-size:12px; margin-top:3px; }
     .tag { display:inline-block; min-width:32px; text-align:center; padding:3px 6px; border-radius:999px; font-weight:700; }
     .tag.r3 { background:#dff4e7; color:#17653a; } .tag.r2 { background:#e5edff; color:#2b4d9d; } .tag.r1 { background:#fae9d2; color:#895315; }
+    .tag.fixed { background:#f3e6fa; color:#70418c; }
     .bitbar { display:flex; min-width:620px; height:48px; } .bit { display:flex; flex-direction:column; justify-content:center;
       text-align:center; overflow:hidden; border:1px solid; border-right:0; padding:2px 4px; white-space:nowrap; }
     .bit:first-child { border-radius:6px 0 0 6px; } .bit:last-child { border-right:1px solid; border-radius:0 6px 6px 0; }
@@ -36,23 +37,24 @@
     footer { margin:18px 0; color:var(--muted); }
     @media print { body { background:white; } main { max-width:none; padding:10px; } .toolbar { display:none; }
       .table-wrap { overflow:visible; border:0; } table { min-width:0; font-size:9px; } th { position:static; } .bitbar { min-width:360px; height:34px; }
-      .cards { grid-template-columns:repeat(5,1fr); } }
+      .cards { grid-template-columns:repeat(6,1fr); } }
   </style>
 </head>
 <body><main>
   <h1>AME instruction encoding review</h1>
   <p>Standalone review artifact generated from <code>src/instructions.adoc</code>. Decoder rule: <code>(word &amp; mask) == match</code>.</p>
   <div class="cards">
-    <div class="card"><strong>122</strong><span>instructions</span></div>
+    <div class="card"><strong>124</strong><span>instructions</span></div>
     <div class="card"><strong>80</strong><span>R3 encodings</span></div>
-    <div class="card"><strong>40</strong><span>R2 encodings</span></div>
+    <div class="card"><strong>41</strong><span>R2 encodings</span></div>
     <div class="card"><strong>2</strong><span>R1 encodings</span></div>
+    <div class="card"><strong>1</strong><span>fixed encodings</span></div>
     <div class="card"><strong>0</strong><span>decode overlaps</span></div>
   </div>
 
   <h2>Encoding formats</h2>
-  <p class="note"><b>Invariant:</b> <code>funct7[31:25]</code>, <code>funct3[14:12]</code>, and <code>opcode[6:0]</code> remain independent fields. Every instruction uses <code>funct3=000</code>; R0 is not defined.</p>
-  <p>R3 occupies <code>funct7=0x00..0x50</code> except reserved value <code>0x35</code>. R2 uses bank <code>0x51</code> with <code>xfunct5=0..31</code> except reserved value <code>0x09</code>, then continues in bank <code>0x52</code>. R1 uses bank <code>0x53</code> with <code>xfunct10=0..1</code>. The 44 <code>funct7</code> values <code>0x54..0x7f</code> remain unallocated.</p>
+  <p class="note"><b>Invariant:</b> <code>funct7[31:25]</code>, <code>funct3[14:12]</code>, and <code>opcode[6:0]</code> remain independent fields. Every instruction uses <code>funct3=000</code>.</p>
+  <p>R3 occupies <code>funct7=0x00..0x50</code> except reserved value <code>0x35</code>. R2 uses bank <code>0x51</code> with <code>xfunct5=0..31</code> except reserved value <code>0x09</code>, then continues in bank <code>0x52</code>. R1 uses bank <code>0x53</code> with <code>xfunct10=0..1</code>. The fixed, no-operand <code>ame.release</code> encoding shares the R2 <code>funct7=0x52</code> bank, using <code>xfunct5=0x0a</code> with <code>rs1=rd=0</code>; every other encoding under that selector is reserved. The 44 <code>funct7</code> values <code>0x54..0x7f</code> remain unallocated.</p>
   <div class="formats">
     <div class="format-row"><b>R3</b><div class="bitbar"><span class="bit fixed w7"><b>funct7</b><small>31:25</small></span><span class="bit operand w5"><b>src2</b><small>24:20</small></span><span class="bit operand w5"><b>src1</b><small>19:15</small></span><span class="bit fixed w3"><b>funct3=0</b><small>14:12</small></span><span class="bit operand w5"><b>dest</b><small>11:7</small></span><span class="bit fixed w7"><b>opcode</b><small>6:0</small></span></div></div>
     <div class="format-row"><b>R2</b><div class="bitbar"><span class="bit fixed w7"><b>funct7</b><small>31:25</small></span><span class="bit fixed w5"><b>xfunct5</b><small>24:20</small></span><span class="bit operand w5"><b>src1</b><small>19:15</small></span><span class="bit fixed w3"><b>funct3=0</b><small>14:12</small></span><span class="bit operand w5"><b>dest</b><small>11:7</small></span><span class="bit fixed w7"><b>opcode</b><small>6:0</small></span></div></div>
@@ -62,8 +64,8 @@
   <h2>All instruction encodings</h2>
   <div class="toolbar">
     <input id="search" type="search" placeholder="Search instruction, mnemonic, or description">
-    <select id="format"><option value="">All formats</option><option>R3</option><option>R2</option><option>R1</option></select>
-    <select id="category"><option value="">All categories</option><option value="Bitwise">Bitwise (16)</option><option value="Compare and Predication">Compare and Predication (8)</option><option value="Datatype Management">Datatype Management (4)</option><option value="Elementwise Arithmetic">Elementwise Arithmetic (31)</option><option value="Elementwise Math Functions">Elementwise Math Functions (18)</option><option value="Matrix Multiply">Matrix Multiply (8)</option><option value="Memory">Memory (6)</option><option value="Permutation">Permutation (12)</option><option value="Reduction">Reduction (10)</option><option value="Register move / data conversion">Register move / data conversion (4)</option><option value="State Management">State Management (5)</option></select>
+    <select id="format"><option value="">All formats</option><option>R3</option><option>R2</option><option>R1</option><option>Fixed</option></select>
+    <select id="category"><option value="">All categories</option><option value="Bitwise">Bitwise (16)</option><option value="Compare and Predication">Compare and Predication (8)</option><option value="Datatype Management">Datatype Management (4)</option><option value="Elementwise Arithmetic">Elementwise Arithmetic (31)</option><option value="Elementwise Math Functions">Elementwise Math Functions (18)</option><option value="Matrix Multiply">Matrix Multiply (8)</option><option value="Memory">Memory (6)</option><option value="Permutation">Permutation (12)</option><option value="Reduction">Reduction (10)</option><option value="Register move / data conversion">Register move / data conversion (4)</option><option value="Resource Management">Resource Management (2)</option><option value="State Management">State Management (5)</option></select>
     <span id="visible"></span>
   </div>
   <div class="table-wrap"><table>
@@ -1121,8 +1123,26 @@
     <td><code>0xfe00707f</code></td>
     <td><code>0x7c00002b</code></td>
   </tr>
-<tr data-format="R2" data-category="State Management">
+<tr data-format="R2" data-category="Resource Management">
     <td class="num">118</td>
+    <td><span class="tag r2">R2</span></td>
+    <td><code>ame.acquire</code></td>
+    <td><code>ame.acquire xd, xs</code><div class="synopsis">Acquire the entire AME backend</div></td>
+    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x52</small></span><span class="bit fixed w5" title="bits 24:20"><b>xfunct5</b><small>0x9</small></span><span class="bit operand w5" title="bits 19:15"><b>xs</b><small>xs</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>xd</b><small>xd</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
+    <td><code>0xfff0707f</code></td>
+    <td><code>0xa490002b</code></td>
+  </tr>
+<tr data-format="Fixed" data-category="Resource Management">
+    <td class="num">119</td>
+    <td><span class="tag fixed">Fixed</span></td>
+    <td><code>ame.release</code></td>
+    <td><code>ame.release</code><div class="synopsis">Release the entire AME backend</div></td>
+    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x52</small></span><span class="bit fixed w5" title="bits 24:20"><b>xfunct5</b><small>0xa</small></span><span class="bit fixed w5" title="bits 19:15"><b>rs1</b><small>0x0</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit fixed w5" title="bits 11:7"><b>rd</b><small>0x0</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
+    <td><code>0xffffffff</code></td>
+    <td><code>0xa4a0002b</code></td>
+  </tr>
+<tr data-format="R2" data-category="State Management">
+    <td class="num">120</td>
     <td><span class="tag r2">R2</span></td>
     <td><code>mmov.a.m</code></td>
     <td><code>mmov.a.m md, acc</code><div class="synopsis">Elementwise unconditional move from accumulator to M register</div></td>
@@ -1131,7 +1151,7 @@
     <td><code>0xa3c0002b</code></td>
   </tr>
 <tr data-format="R2" data-category="State Management">
-    <td class="num">119</td>
+    <td class="num">121</td>
     <td><span class="tag r2">R2</span></td>
     <td><code>mmov.m.a</code></td>
     <td><code>mmov.m.a acc, ms</code><div class="synopsis">Elementwise unconditional move from M register to accumulator</div></td>
@@ -1140,7 +1160,7 @@
     <td><code>0xa3d0002b</code></td>
   </tr>
 <tr data-format="R2" data-category="State Management">
-    <td class="num">120</td>
+    <td class="num">122</td>
     <td><span class="tag r2">R2</span></td>
     <td><code>mmov.m.m</code></td>
     <td><code>mmov.m.m md, ms</code><div class="synopsis">Elementwise unconditional move between M registers</div></td>
@@ -1149,7 +1169,7 @@
     <td><code>0xa3e0002b</code></td>
   </tr>
 <tr data-format="R1" data-category="State Management">
-    <td class="num">121</td>
+    <td class="num">123</td>
     <td><span class="tag r1">R1</span></td>
     <td><code>mzero.2d.acc</code></td>
     <td><code>mzero.2d.acc acc</code><div class="synopsis">Clear accumulator tile</div></td>
@@ -1158,7 +1178,7 @@
     <td><code>0xa600002b</code></td>
   </tr>
 <tr data-format="R1" data-category="State Management">
-    <td class="num">122</td>
+    <td class="num">124</td>
     <td><span class="tag r1">R1</span></td>
     <td><code>mzero.2d.m</code></td>
     <td><code>mzero.2d.m md</code><div class="synopsis">Clear tensor register</div></td>
@@ -1167,7 +1187,7 @@
     <td><code>0xa600802b</code></td>
   </tr></tbody>
   </table></div>
-  <footer>Blue fields are fixed selectors; green fields are register operands. Category counts: Bitwise=16, Compare and Predication=8, Datatype Management=4, Elementwise Arithmetic=31, Elementwise Math Functions=18, Matrix Multiply=8, Memory=6, Permutation=12, Reduction=10, Register move / data conversion=4, State Management=5.</footer>
+  <footer>Blue fields are fixed selectors; green fields are register operands. Category counts: Bitwise=16, Compare and Predication=8, Datatype Management=4, Elementwise Arithmetic=31, Elementwise Math Functions=18, Matrix Multiply=8, Memory=6, Permutation=12, Reduction=10, Register move / data conversion=4, Resource Management=2, State Management=5.</footer>
 </main>
 <script>
   const search = document.querySelector('#search'); const fmt = document.querySelector('#format');

--- a/INSTRUCTION_ENCODINGS.md
+++ b/INSTRUCTION_ENCODINGS.md
@@ -8,143 +8,146 @@ The canonical decoder test is `(instruction_word & mask) == match`. Fixed fields
 
 | Check | Count |
 |---|---:|
-| Instructions | 122 |
+| Instructions | 124 |
+| Fixed encodings | 1 |
 | R1 encodings | 2 |
-| R2 encodings | 40 |
+| R2 encodings | 41 |
 | R3 encodings | 80 |
 | Exact duplicate decode patterns | 0 |
 | Partial decode-space overlaps | 0 |
 
 ## Format allocation policy
 
-Every encoding retains `funct7[31:25]`, `funct3[14:12]`, and `opcode[6:0]`. R2 converts only `src2[24:20]` to `xfunct5`; R1 also converts `src1[19:15]`, yielding `xfunct10`. All instructions use `funct3=000`; R0 is not defined.
+Every encoding retains `funct7[31:25]`, `funct3[14:12]`, and `opcode[6:0]`. R2 converts only `src2[24:20]` to `xfunct5`; R1 also converts `src1[19:15]`, yielding `xfunct10`. All instructions use `funct3=000`. The no-operand `ame.release` encoding uses a reserved R2 selector and fixes both R2 operand fields to zero; it does not define another register format.
 
-A `(funct7, funct3, opcode)` bank belongs to only one format. This rule prevents a more-specific R1/R2 pattern from being hidden inside an R2/R3 decode.
-R3 uses `funct7=0x00..0x50` except the reserved value `0x35`. R2 uses `funct7=0x51` with `xfunct5=0..31` except the reserved value `0x09`, before continuing at `funct7=0x52`; R1 uses `funct7=0x53` with `xfunct10=0..1`. Values `0x54..0x7f` remain free.
+A `(funct7, funct3, opcode)` bank belongs to only one register format. A fixed no-operand instruction may occupy a reserved selector in that bank when every other encoding under the selector is reserved.
+R3 uses `funct7=0x00..0x50` except the reserved value `0x35`. R2 uses `funct7=0x51` with `xfunct5=0..31` except the reserved value `0x09`, before continuing at `funct7=0x52`; R1 uses `funct7=0x53` with `xfunct10=0..1`. The fixed `ame.release` encoding shares the R2 `funct7=0x52` bank, using `xfunct5=0x0a` with `rs1=rd=0`. Values `0x54..0x7f` remain free.
 
 ## All instruction encodings
 
 | # | Format | Instruction | Mnemonic | Operand fields | Function/fixed fields | Mask | Match |
 |---:|---|---|---|---|---|---|---|
-| 1 | R2 | `agettyp` | `agettyp xd, ad` | `ad[19:15]`; `xd[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x00`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa200002b` |
-| 2 | R2 | `asettyp` | `asettyp ad, xs1` | `xs1[19:15]`; `ad[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x01`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa210002b` |
-| 3 | R2 | `mabs.ew` | `mabs.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x04`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa240002b` |
-| 4 | R3 | `mabsdiff.ew` | `mabsdiff.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x00`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0000002b` |
-| 5 | R3 | `mabsdiff.ew.x` | `mabsdiff.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x01`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0200002b` |
-| 6 | R3 | `madd.ew` | `madd.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x02`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0400002b` |
-| 7 | R3 | `madd.ew.x` | `madd.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x03`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0600002b` |
-| 8 | R3 | `mand.ew` | `mand.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x1a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3400002b` |
-| 9 | R3 | `mand.ew.x` | `mand.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x1b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3600002b` |
-| 10 | R3 | `mandnot.ew` | `mandnot.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x1c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3800002b` |
-| 11 | R3 | `mandnot.ew.x` | `mandnot.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x1d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3a00002b` |
-| 12 | R3 | `mcmovge.ew` | `mcmovge.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x2a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5400002b` |
-| 13 | R3 | `mcmovlt.ew` | `mcmovlt.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x2b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5600002b` |
-| 14 | R3 | `mcmpge.ew` | `mcmpge.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x2c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5800002b` |
-| 15 | R3 | `mcmpge.ew.x` | `mcmpge.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x2d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5a00002b` |
-| 16 | R3 | `mcmplt.ew` | `mcmplt.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x2e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5c00002b` |
-| 17 | R3 | `mcmplt.ew.x` | `mcmplt.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x2f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5e00002b` |
-| 18 | R3 | `mcolgather.ew` | `mcolgather.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x33`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6600002b` |
-| 19 | R3 | `mcolshift.ew.x` | `mcolshift.ew.x md, ms1, xs1` | `xs1[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x34`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6800002b` |
-| 20 | R2 | `mcolunzip.ew` | `mcolunzip.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2a0002b` |
-| 21 | R2 | `mcolzip.ew` | `mcolzip.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2b0002b` |
-| 22 | R2 | `mconv.ew` | `mconv.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2d0002b` |
-| 23 | R3 | `mmov.m.x` | `mmov.m.x md, xs1, xtyp` | `xtyp[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x32`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6400002b` |
-| 24 | R2 | `mcos.ew` | `mcos.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2e0002b` |
-| 25 | R2 | `mexp2.ew` | `mexp2.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2f0002b` |
-| 26 | R2 | `mfrintm.ew` | `mfrintm.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x05`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa250002b` |
-| 27 | R2 | `mfrintn.ew` | `mfrintn.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x06`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa260002b` |
-| 28 | R2 | `mfrintp.ew` | `mfrintp.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x07`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa270002b` |
-| 29 | R2 | `mfrintz.ew` | `mfrintz.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x08`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa280002b` |
-| 30 | R2 | `mgettyp` | `mgettyp xd, ms1` | `ms1[19:15]`; `xd[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x02`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa220002b` |
-| 31 | R3 | `mhdiff.ew` | `mhdiff.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x04`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0800002b` |
-| 32 | R3 | `mhdiff.ew.x` | `mhdiff.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x05`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0a00002b` |
-| 33 | R3 | `mldexp.ew` | `mldexp.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7e00002b` |
-| 34 | R3 | `mldexp.ew.x` | `mldexp.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x40`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8000002b` |
-| 35 | R3 | `mldexpacc.ew` | `mldexpacc.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x41`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8200002b` |
-| 36 | R3 | `mldexpacc.ew.x` | `mldexpacc.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x42`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8400002b` |
-| 37 | R2 | `mlog2.ew` | `mlog2.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x10`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa300002b` |
-| 38 | R3 | `mlog2sub.ew` | `mlog2sub.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x43`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8600002b` |
-| 39 | R3 | `mlog2sub.ew.x` | `mlog2sub.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x44`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8800002b` |
-| 40 | R2 | `mls` | `mls md, xs1` | `xs1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x16`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa360002b` |
-| 41 | R2 | `mls.cm` | `mls.cm md, xs1` | `xs1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x17`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa370002b` |
-| 42 | R2 | `mls.rm` | `mls.rm md, xs1` | `xs1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x18`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa380002b` |
-| 43 | R3 | `mmax.ew` | `mmax.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x06`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0c00002b` |
-| 44 | R3 | `mmax.ew.x` | `mmax.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x07`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0e00002b` |
-| 45 | R3 | `mmean.ew` | `mmean.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x08`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1000002b` |
-| 46 | R3 | `mmean.ew.x` | `mmean.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x09`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1200002b` |
-| 47 | R3 | `mmin.ew` | `mmin.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x0a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1400002b` |
-| 48 | R3 | `mmin.ew.x` | `mmin.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x0b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1600002b` |
-| 49 | R2 | `mmov.a.m` | `mmov.a.m md, acc` | `acc[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3c0002b` |
-| 50 | R2 | `mmov.m.a` | `mmov.m.a acc, ms` | `ms[19:15]`; `acc[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3d0002b` |
-| 51 | R2 | `mmov.m.m` | `mmov.m.m md, ms` | `ms[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3e0002b` |
-| 52 | R3 | `mmul.2d` | `mmul.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x49`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9200002b` |
-| 53 | R3 | `mmul.ew` | `mmul.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x0c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1800002b` |
-| 54 | R3 | `mmul.ew.x` | `mmul.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x0d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1a00002b` |
-| 55 | R3 | `mmulacc.2d` | `mmulacc.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9400002b` |
-| 56 | R3 | `mmulacc.ew` | `mmulacc.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x0e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1c00002b` |
-| 57 | R3 | `mmulacc.ew.x` | `mmulacc.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x0f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1e00002b` |
-| 58 | R3 | `mmulaccneg.2d` | `mmulaccneg.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9600002b` |
-| 59 | R3 | `mmulaccneg.ew` | `mmulaccneg.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x10`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2000002b` |
-| 60 | R3 | `mmulaccneg.ew.x` | `mmulaccneg.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x11`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2200002b` |
-| 61 | R3 | `mmuladd.ew` | `mmuladd.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x12`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2400002b` |
-| 62 | R3 | `mmuladd.ew.x` | `mmuladd.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x13`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2600002b` |
-| 63 | R3 | `mmulat.2d` | `mmulat.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9800002b` |
-| 64 | R3 | `mmulatacc.2d` | `mmulatacc.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9a00002b` |
-| 65 | R3 | `mmulbt.2d` | `mmulbt.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9c00002b` |
-| 66 | R3 | `mmulbtacc.2d` | `mmulbtacc.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9e00002b` |
-| 67 | R3 | `mmulneg.2d` | `mmulneg.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x50`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0xa000002b` |
-| 68 | R3 | `mmulneg.ew` | `mmulneg.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x14`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2800002b` |
-| 69 | R3 | `mmulneg.ew.x` | `mmulneg.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x15`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2a00002b` |
-| 70 | R3 | `mmulsub.ew` | `mmulsub.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x16`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2c00002b` |
-| 71 | R3 | `mmulsub.ew.x` | `mmulsub.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x17`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2e00002b` |
-| 72 | R3 | `mor.ew` | `mor.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x1e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3c00002b` |
-| 73 | R3 | `mor.ew.x` | `mor.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x1f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3e00002b` |
-| 74 | R3 | `mornot.ew` | `mornot.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x20`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4000002b` |
-| 75 | R3 | `mornot.ew.x` | `mornot.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x21`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4200002b` |
-| 76 | R3 | `mpack.ew.x` | `mpack.ew.x md, ms1, xs1` | `xs1[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7a00002b` |
-| 77 | R2 | `mprefixadd.col` | `mprefixadd.col md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3f0002b` |
-| 78 | R2 | `mprefixadd.row` | `mprefixadd.row md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x00`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa400002b` |
-| 79 | R2 | `mprefixmax.col` | `mprefixmax.col md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x01`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa410002b` |
-| 80 | R2 | `mprefixmax.row` | `mprefixmax.row md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x02`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa420002b` |
-| 81 | R3 | `mrdexp.ew` | `mrdexp.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x45`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8a00002b` |
-| 82 | R3 | `mrdexpacc.ew` | `mrdexpacc.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x46`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8c00002b` |
-| 83 | R2 | `mrec.ew` | `mrec.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x11`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa310002b` |
-| 84 | R2 | `mreduceadd.col` | `mreduceadd.col md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x03`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa430002b` |
-| 85 | R2 | `mreduceadd.row` | `mreduceadd.row md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x04`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa440002b` |
-| 86 | R2 | `mreducemax.col` | `mreducemax.col md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x05`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa450002b` |
-| 87 | R2 | `mreducemax.row` | `mreducemax.row md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x06`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa460002b` |
-| 88 | R2 | `mreducemin.col` | `mreducemin.col md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x07`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa470002b` |
-| 89 | R2 | `mreducemin.row` | `mreducemin.row md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x08`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa480002b` |
-| 90 | R3 | `mrowgather.ew` | `mrowgather.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x36`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6c00002b` |
-| 91 | R3 | `mrowshift.ew.x` | `mrowshift.ew.x md, ms1, xs1` | `xs1[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x37`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6e00002b` |
-| 92 | R2 | `mrowunzip.ew` | `mrowunzip.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2c0002b` |
-| 93 | R3 | `mrowzip.ew` | `mrowzip.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x38`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7000002b` |
-| 94 | R2 | `mrsqrt.ew` | `mrsqrt.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x12`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa320002b` |
-| 95 | R3 | `mscatadd.col` | `mscatadd.col md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x39`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7200002b` |
-| 96 | R3 | `mscatadd.row` | `mscatadd.row md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7400002b` |
-| 97 | R3 | `mscatmax.col` | `mscatmax.col md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7600002b` |
-| 98 | R3 | `mscatmax.row` | `mscatmax.row md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7800002b` |
-| 99 | R3 | `mselge.ew` | `mselge.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x30`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6000002b` |
-| 100 | R3 | `msellt.ew` | `msellt.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x31`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6200002b` |
-| 101 | R2 | `msettyp` | `msettyp md, xs1` | `xs1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x03`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa230002b` |
-| 102 | R2 | `msin.ew` | `msin.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x13`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa330002b` |
-| 103 | R3 | `msll.ew` | `msll.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x22`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4400002b` |
-| 104 | R3 | `msll.ew.x` | `msll.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x23`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4600002b` |
-| 105 | R2 | `msqrt.ew` | `msqrt.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x14`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa340002b` |
-| 106 | R3 | `msra.ew` | `msra.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x24`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4800002b` |
-| 107 | R3 | `msra.ew.x` | `msra.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x25`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4a00002b` |
-| 108 | R3 | `msrl.ew` | `msrl.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x26`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4c00002b` |
-| 109 | R3 | `msrl.ew.x` | `msrl.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x27`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4e00002b` |
-| 110 | R2 | `mss` | `mss ms1, xs1` | `xs1[19:15]`; `ms1[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x19`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa390002b` |
-| 111 | R2 | `mss.cm` | `mss.cm ms1, xs1` | `xs1[19:15]`; `ms1[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3a0002b` |
-| 112 | R2 | `mss.rm` | `mss.rm ms1, xs1` | `xs1[19:15]`; `ms1[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3b0002b` |
-| 113 | R3 | `msub.ew` | `msub.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x18`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3000002b` |
-| 114 | R3 | `msub.ew.x` | `msub.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x19`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3200002b` |
-| 115 | R3 | `msublog2.ew` | `msublog2.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x47`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8e00002b` |
-| 116 | R3 | `msublog2.ew.x` | `msublog2.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x48`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9000002b` |
-| 117 | R2 | `mtanh.ew` | `mtanh.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x15`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa350002b` |
-| 118 | R3 | `munpack.ew.x` | `munpack.ew.x md, ms1, xs1` | `xs1[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7c00002b` |
-| 119 | R3 | `mxor.ew` | `mxor.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x28`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5000002b` |
-| 120 | R3 | `mxor.ew.x` | `mxor.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x29`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5200002b` |
-| 121 | R1 | `mzero.2d.acc` | `mzero.2d.acc acc` | `acc[11:7]` | `[31:25]=0x53` (`ame-enc-r1-bank-funct7`); `[24:20]=0x00`; `[19:15]=0x00`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfffff07f` | `0xa600002b` |
-| 122 | R1 | `mzero.2d.m` | `mzero.2d.m md` | `md[11:7]` | `[31:25]=0x53` (`ame-enc-r1-bank-funct7`); `[24:20]=0x00`; `[19:15]=0x01`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfffff07f` | `0xa600802b` |
+| 1 | R2 | `ame.acquire` | `ame.acquire xd, xs` | `xs[19:15]`; `xd[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x09`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa490002b` |
+| 2 | Fixed | `ame.release` | `ame.release` |  | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x0a`; `[19:15]=0x00`; `[14:12]=0x0` (`ame-enc-funct3`); `[11:7]=0x00`; `[6:0]=0x2b` | `0xffffffff` | `0xa4a0002b` |
+| 3 | R2 | `agettyp` | `agettyp xd, ad` | `ad[19:15]`; `xd[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x00`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa200002b` |
+| 4 | R2 | `asettyp` | `asettyp ad, xs1` | `xs1[19:15]`; `ad[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x01`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa210002b` |
+| 5 | R2 | `mabs.ew` | `mabs.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x04`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa240002b` |
+| 6 | R3 | `mabsdiff.ew` | `mabsdiff.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x00`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0000002b` |
+| 7 | R3 | `mabsdiff.ew.x` | `mabsdiff.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x01`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0200002b` |
+| 8 | R3 | `madd.ew` | `madd.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x02`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0400002b` |
+| 9 | R3 | `madd.ew.x` | `madd.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x03`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0600002b` |
+| 10 | R3 | `mand.ew` | `mand.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x1a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3400002b` |
+| 11 | R3 | `mand.ew.x` | `mand.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x1b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3600002b` |
+| 12 | R3 | `mandnot.ew` | `mandnot.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x1c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3800002b` |
+| 13 | R3 | `mandnot.ew.x` | `mandnot.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x1d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3a00002b` |
+| 14 | R3 | `mcmovge.ew` | `mcmovge.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x2a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5400002b` |
+| 15 | R3 | `mcmovlt.ew` | `mcmovlt.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x2b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5600002b` |
+| 16 | R3 | `mcmpge.ew` | `mcmpge.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x2c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5800002b` |
+| 17 | R3 | `mcmpge.ew.x` | `mcmpge.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x2d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5a00002b` |
+| 18 | R3 | `mcmplt.ew` | `mcmplt.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x2e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5c00002b` |
+| 19 | R3 | `mcmplt.ew.x` | `mcmplt.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x2f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5e00002b` |
+| 20 | R3 | `mcolgather.ew` | `mcolgather.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x33`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6600002b` |
+| 21 | R3 | `mcolshift.ew.x` | `mcolshift.ew.x md, ms1, xs1` | `xs1[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x34`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6800002b` |
+| 22 | R2 | `mcolunzip.ew` | `mcolunzip.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2a0002b` |
+| 23 | R2 | `mcolzip.ew` | `mcolzip.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2b0002b` |
+| 24 | R2 | `mconv.ew` | `mconv.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2d0002b` |
+| 25 | R3 | `mmov.m.x` | `mmov.m.x md, xs1, xtyp` | `xtyp[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x32`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6400002b` |
+| 26 | R2 | `mcos.ew` | `mcos.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2e0002b` |
+| 27 | R2 | `mexp2.ew` | `mexp2.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2f0002b` |
+| 28 | R2 | `mfrintm.ew` | `mfrintm.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x05`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa250002b` |
+| 29 | R2 | `mfrintn.ew` | `mfrintn.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x06`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa260002b` |
+| 30 | R2 | `mfrintp.ew` | `mfrintp.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x07`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa270002b` |
+| 31 | R2 | `mfrintz.ew` | `mfrintz.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x08`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa280002b` |
+| 32 | R2 | `mgettyp` | `mgettyp xd, ms1` | `ms1[19:15]`; `xd[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x02`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa220002b` |
+| 33 | R3 | `mhdiff.ew` | `mhdiff.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x04`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0800002b` |
+| 34 | R3 | `mhdiff.ew.x` | `mhdiff.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x05`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0a00002b` |
+| 35 | R3 | `mldexp.ew` | `mldexp.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7e00002b` |
+| 36 | R3 | `mldexp.ew.x` | `mldexp.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x40`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8000002b` |
+| 37 | R3 | `mldexpacc.ew` | `mldexpacc.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x41`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8200002b` |
+| 38 | R3 | `mldexpacc.ew.x` | `mldexpacc.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x42`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8400002b` |
+| 39 | R2 | `mlog2.ew` | `mlog2.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x10`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa300002b` |
+| 40 | R3 | `mlog2sub.ew` | `mlog2sub.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x43`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8600002b` |
+| 41 | R3 | `mlog2sub.ew.x` | `mlog2sub.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x44`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8800002b` |
+| 42 | R2 | `mls` | `mls md, xs1` | `xs1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x16`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa360002b` |
+| 43 | R2 | `mls.cm` | `mls.cm md, xs1` | `xs1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x17`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa370002b` |
+| 44 | R2 | `mls.rm` | `mls.rm md, xs1` | `xs1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x18`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa380002b` |
+| 45 | R3 | `mmax.ew` | `mmax.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x06`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0c00002b` |
+| 46 | R3 | `mmax.ew.x` | `mmax.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x07`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x0e00002b` |
+| 47 | R3 | `mmean.ew` | `mmean.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x08`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1000002b` |
+| 48 | R3 | `mmean.ew.x` | `mmean.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x09`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1200002b` |
+| 49 | R3 | `mmin.ew` | `mmin.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x0a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1400002b` |
+| 50 | R3 | `mmin.ew.x` | `mmin.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x0b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1600002b` |
+| 51 | R2 | `mmov.a.m` | `mmov.a.m md, acc` | `acc[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3c0002b` |
+| 52 | R2 | `mmov.m.a` | `mmov.m.a acc, ms` | `ms[19:15]`; `acc[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3d0002b` |
+| 53 | R2 | `mmov.m.m` | `mmov.m.m md, ms` | `ms[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3e0002b` |
+| 54 | R3 | `mmul.2d` | `mmul.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x49`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9200002b` |
+| 55 | R3 | `mmul.ew` | `mmul.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x0c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1800002b` |
+| 56 | R3 | `mmul.ew.x` | `mmul.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x0d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1a00002b` |
+| 57 | R3 | `mmulacc.2d` | `mmulacc.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9400002b` |
+| 58 | R3 | `mmulacc.ew` | `mmulacc.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x0e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1c00002b` |
+| 59 | R3 | `mmulacc.ew.x` | `mmulacc.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x0f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x1e00002b` |
+| 60 | R3 | `mmulaccneg.2d` | `mmulaccneg.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9600002b` |
+| 61 | R3 | `mmulaccneg.ew` | `mmulaccneg.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x10`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2000002b` |
+| 62 | R3 | `mmulaccneg.ew.x` | `mmulaccneg.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x11`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2200002b` |
+| 63 | R3 | `mmuladd.ew` | `mmuladd.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x12`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2400002b` |
+| 64 | R3 | `mmuladd.ew.x` | `mmuladd.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x13`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2600002b` |
+| 65 | R3 | `mmulat.2d` | `mmulat.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9800002b` |
+| 66 | R3 | `mmulatacc.2d` | `mmulatacc.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9a00002b` |
+| 67 | R3 | `mmulbt.2d` | `mmulbt.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9c00002b` |
+| 68 | R3 | `mmulbtacc.2d` | `mmulbtacc.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x4f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9e00002b` |
+| 69 | R3 | `mmulneg.2d` | `mmulneg.2d acc, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `acc[11:7]` | `[31:25]=0x50`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0xa000002b` |
+| 70 | R3 | `mmulneg.ew` | `mmulneg.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x14`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2800002b` |
+| 71 | R3 | `mmulneg.ew.x` | `mmulneg.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x15`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2a00002b` |
+| 72 | R3 | `mmulsub.ew` | `mmulsub.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x16`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2c00002b` |
+| 73 | R3 | `mmulsub.ew.x` | `mmulsub.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x17`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x2e00002b` |
+| 74 | R3 | `mor.ew` | `mor.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x1e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3c00002b` |
+| 75 | R3 | `mor.ew.x` | `mor.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x1f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3e00002b` |
+| 76 | R3 | `mornot.ew` | `mornot.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x20`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4000002b` |
+| 77 | R3 | `mornot.ew.x` | `mornot.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x21`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4200002b` |
+| 78 | R3 | `mpack.ew.x` | `mpack.ew.x md, ms1, xs1` | `xs1[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7a00002b` |
+| 79 | R2 | `mprefixadd.col` | `mprefixadd.col md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1f`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3f0002b` |
+| 80 | R2 | `mprefixadd.row` | `mprefixadd.row md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x00`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa400002b` |
+| 81 | R2 | `mprefixmax.col` | `mprefixmax.col md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x01`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa410002b` |
+| 82 | R2 | `mprefixmax.row` | `mprefixmax.row md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x02`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa420002b` |
+| 83 | R3 | `mrdexp.ew` | `mrdexp.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x45`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8a00002b` |
+| 84 | R3 | `mrdexpacc.ew` | `mrdexpacc.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x46`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8c00002b` |
+| 85 | R2 | `mrec.ew` | `mrec.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x11`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa310002b` |
+| 86 | R2 | `mreduceadd.col` | `mreduceadd.col md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x03`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa430002b` |
+| 87 | R2 | `mreduceadd.row` | `mreduceadd.row md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x04`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa440002b` |
+| 88 | R2 | `mreducemax.col` | `mreducemax.col md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x05`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa450002b` |
+| 89 | R2 | `mreducemax.row` | `mreducemax.row md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x06`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa460002b` |
+| 90 | R2 | `mreducemin.col` | `mreducemin.col md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x07`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa470002b` |
+| 91 | R2 | `mreducemin.row` | `mreducemin.row md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x52` (`ame-enc-r2-bank1-funct7`); `[24:20]=0x08`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa480002b` |
+| 92 | R3 | `mrowgather.ew` | `mrowgather.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x36`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6c00002b` |
+| 93 | R3 | `mrowshift.ew.x` | `mrowshift.ew.x md, ms1, xs1` | `xs1[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x37`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6e00002b` |
+| 94 | R2 | `mrowunzip.ew` | `mrowunzip.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2c0002b` |
+| 95 | R3 | `mrowzip.ew` | `mrowzip.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x38`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7000002b` |
+| 96 | R2 | `mrsqrt.ew` | `mrsqrt.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x12`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa320002b` |
+| 97 | R3 | `mscatadd.col` | `mscatadd.col md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x39`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7200002b` |
+| 98 | R3 | `mscatadd.row` | `mscatadd.row md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7400002b` |
+| 99 | R3 | `mscatmax.col` | `mscatmax.col md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7600002b` |
+| 100 | R3 | `mscatmax.row` | `mscatmax.row md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7800002b` |
+| 101 | R3 | `mselge.ew` | `mselge.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x30`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6000002b` |
+| 102 | R3 | `msellt.ew` | `msellt.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x31`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6200002b` |
+| 103 | R2 | `msettyp` | `msettyp md, xs1` | `xs1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x03`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa230002b` |
+| 104 | R2 | `msin.ew` | `msin.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x13`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa330002b` |
+| 105 | R3 | `msll.ew` | `msll.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x22`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4400002b` |
+| 106 | R3 | `msll.ew.x` | `msll.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x23`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4600002b` |
+| 107 | R2 | `msqrt.ew` | `msqrt.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x14`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa340002b` |
+| 108 | R3 | `msra.ew` | `msra.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x24`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4800002b` |
+| 109 | R3 | `msra.ew.x` | `msra.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x25`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4a00002b` |
+| 110 | R3 | `msrl.ew` | `msrl.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x26`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4c00002b` |
+| 111 | R3 | `msrl.ew.x` | `msrl.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x27`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x4e00002b` |
+| 112 | R2 | `mss` | `mss ms1, xs1` | `xs1[19:15]`; `ms1[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x19`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa390002b` |
+| 113 | R2 | `mss.cm` | `mss.cm ms1, xs1` | `xs1[19:15]`; `ms1[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3a0002b` |
+| 114 | R2 | `mss.rm` | `mss.rm ms1, xs1` | `xs1[19:15]`; `ms1[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x1b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa3b0002b` |
+| 115 | R3 | `msub.ew` | `msub.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x18`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3000002b` |
+| 116 | R3 | `msub.ew.x` | `msub.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x19`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x3200002b` |
+| 117 | R3 | `msublog2.ew` | `msublog2.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x47`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x8e00002b` |
+| 118 | R3 | `msublog2.ew.x` | `msublog2.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x48`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x9000002b` |
+| 119 | R2 | `mtanh.ew` | `mtanh.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x15`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa350002b` |
+| 120 | R3 | `munpack.ew.x` | `munpack.ew.x md, ms1, xs1` | `xs1[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7c00002b` |
+| 121 | R3 | `mxor.ew` | `mxor.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x28`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5000002b` |
+| 122 | R3 | `mxor.ew.x` | `mxor.ew.x md, xs1, ms2` | `ms2[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x29`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x5200002b` |
+| 123 | R1 | `mzero.2d.acc` | `mzero.2d.acc acc` | `acc[11:7]` | `[31:25]=0x53` (`ame-enc-r1-bank-funct7`); `[24:20]=0x00`; `[19:15]=0x00`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfffff07f` | `0xa600002b` |
+| 124 | R1 | `mzero.2d.m` | `mzero.2d.m md` | `md[11:7]` | `[31:25]=0x53` (`ame-enc-r1-bank-funct7`); `[24:20]=0x00`; `[19:15]=0x01`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfffff07f` | `0xa600802b` |

--- a/scripts/check-instruction-encodings.rb
+++ b/scripts/check-instruction-encodings.rb
@@ -6,6 +6,7 @@
 
 attributes_path = File.join(__dir__, "..", "src", "instruction-encoding-allocations.adoc")
 instructions_path = File.join(__dir__, "..", "src", "instructions.adoc")
+instructions_source = File.read(instructions_path)
 
 attributes = {}
 File.foreach(attributes_path) do |line|
@@ -68,8 +69,8 @@ File.foreach(instructions_path) do |line|
     abort "#{instruction} must retain fixed funct7[31:25], funct3[14:12], and opcode[6:0] fields"
   end
   abort "#{instruction} must use CUSTOM-1 opcode 0x2b" unless (value & opcode_mask) == 0x2b
-  abort "#{instruction} has no destination operand in bits 11:7; R0 is not defined" unless (mask & dest_mask).zero?
 
+  dest_fixed = (mask & dest_mask) == dest_mask
   src1_fixed = (mask & src1_mask) == src1_mask
   src2_fixed = (mask & src2_mask) == src2_mask
   format = if !src2_fixed
@@ -77,8 +78,10 @@ File.foreach(instructions_path) do |line|
              "R3"
            elsif !src1_fixed
              "R2"
-           else
+           elsif !dest_fixed
              "R1"
+           else
+             "Fixed"
            end
 
   extension = case format
@@ -95,9 +98,17 @@ abort "unused managed encoding attributes: #{unused.sort.join(', ')}" unless unu
 
 # Keep the Chapter 2 instruction list authoritative for classification and
 # guarantee that every detailed instruction appears in exactly one list.
+unallocated_names = []
+instructions_source.scan(/^=== `([^`]+)`\n(.*?)(?=^=== `|\z)/m) do |name, section|
+  next unless section.include?("This specification does not assign an instruction encoding.")
+
+  abort "#{name} is marked unallocated but has an encoding diagram" if section.include?('{"reg":')
+  unallocated_names << name
+end
+
 category_by_instruction = {}
 current_category = nil
-File.read(instructions_path).split("\n<<<\n", 2).first.each_line do |line|
+instructions_source.split("\n<<<\n", 2).first.each_line do |line|
   heading = line.match(/^(.+)::$/)
   current_category = heading[1] if heading
   mnemonic = line.match(/^a\| `([^\s`]+)/)
@@ -107,7 +118,7 @@ File.read(instructions_path).split("\n<<<\n", 2).first.each_line do |line|
 
   category_by_instruction[mnemonic[1]] = current_category
 end
-detailed_names = entries.map { |entry| entry[:name] }
+detailed_names = entries.map { |entry| entry[:name] } + unallocated_names
 missing_categories = detailed_names - category_by_instruction.keys
 extra_categories = category_by_instruction.keys - detailed_names
 abort "instructions missing from Chapter 2 categories: #{missing_categories.join(', ')}" unless missing_categories.empty?
@@ -119,12 +130,14 @@ abort "AME instructions must all use funct3=0, found #{funct3_values.sort.join('
 reserved_funct7 = {
   "R3" => [0x35],
   "R2" => [],
-  "R1" => []
+  "R1" => [],
+  "Fixed" => []
 }
 expected_funct7 = {
   "R3" => (0x00..0x50).to_a - reserved_funct7.fetch("R3"),
   "R2" => [0x51, 0x52],
-  "R1" => [0x53]
+  "R1" => [0x53],
+  "Fixed" => [0x52]
 }
 expected_funct7.each do |format_name, expected|
   actual = entries.select { |entry| entry[:format] == format_name }
@@ -132,11 +145,17 @@ expected_funct7.each do |format_name, expected|
   abort "#{format_name} funct7 banks #{actual.inspect}, expected #{expected.inspect}" unless actual == expected
 end
 
+release = entries.find { |entry| entry[:name] == "ame.release" }
+abort "ame.release must have a fully fixed encoding" unless release &&
+  release[:format] == "Fixed" && release[:mask] == 0xffffffff
+abort "ame.release must use funct7=0x52, xfunct5=0x0a, rs1=0, and rd=0" unless
+  release[:value] == 0xa4a0002b
+
 # Keep every WaveDrom operand field synchronized with the normative
 # Decode Variables block.  Collision checking alone cannot detect a diagram
 # that assigns an operand to different bits than the pseudocode reads.
 field_errors = []
-File.read(instructions_path).scan(/^=== `([^`]+)`\n(.*?)(?=^=== `|\z)/m) do |name, section|
+instructions_source.scan(/^=== `([^`]+)`\n(.*?)(?=^=== `|\z)/m) do |name, section|
   diagram = section.lines.find { |line| line.start_with?('{"reg":') }
   next unless diagram
 
@@ -174,11 +193,15 @@ File.read(instructions_path).scan(/^=== `([^`]+)`\n(.*?)(?=^=== `|\z)/m) do |nam
 end
 abort "managed encoding/decode mismatch:\n  #{field_errors.join("\n  ")}" unless field_errors.empty?
 
-# The same (funct7, funct3, opcode) bank cannot mix arities.  Otherwise a
-# more-specific R1/R2 decode would be a subset of an R2/R3 decode even if the
-# currently allocated xfunct values happened not to collide.
+# A bank normally cannot mix arities. The only exception is ame.release, a
+# fully fixed member of the R2 Resource Management bank whose xfunct5 selector
+# is reserved from ordinary R2 allocation.
 mixed_banks = entries.group_by { |entry| entry[:bank] }.map do |bank, members|
   formats = members.map { |entry| entry[:format] }.uniq
+  fixed_members = members.select { |entry| entry[:format] == "Fixed" }
+  next if formats.sort == ["Fixed", "R2"] &&
+          fixed_members.map { |entry| entry[:name] } == ["ame.release"]
+
   [bank, formats, members] if formats.length > 1
 end.compact
 unless mixed_banks.empty?
@@ -193,7 +216,8 @@ end
 # funct7 bank.  This turns the space-saving policy into a checked invariant
 # rather than a documentation preference.
 reserved_extensions = {
-  ["R2", 0x51] => [9]
+  ["R2", 0x51] => [9],
+  ["R2", 0x52] => [10]
 }
 [["R2", 32], ["R1", 1024]].each do |format_name, capacity|
   entries.select { |entry| entry[:format] == format_name }
@@ -233,6 +257,7 @@ end
 format_counts = entries.group_by { |entry| entry[:format] }.transform_values(&:length)
 puts "checked #{entries.length} instruction encodings " \
      "(R3=#{format_counts.fetch('R3', 0)}, R2=#{format_counts.fetch('R2', 0)}, " \
-     "R1=#{format_counts.fetch('R1', 0)}): single funct3=0, stable selector skeleton, exclusive format banks, " \
+     "R1=#{format_counts.fetch('R1', 0)}, Fixed=#{format_counts.fetch('Fixed', 0)}): " \
+     "single funct3=0, stable selector skeleton, controlled fixed-form sharing, " \
      "dense xfunct allocation, unique Chapter 2 classification, " \
      "fields match decode variables, no duplicates or overlaps"

--- a/scripts/generate-instruction-encoding-html.rb
+++ b/scripts/generate-instruction-encoding-html.rb
@@ -35,9 +35,17 @@ instructions_source.split("\n<<<\n", 2).first.each_line do |line|
 end
 
 entries = []
+unallocated_names = []
 instructions_source.scan(/^=== `([^`]+)`\n(.*?)(?=^=== `|\z)/m) do |name, section|
   diagram = section.lines.find { |line| line.start_with?('{"reg":') }
-  abort "#{name} has no WaveDrom encoding" unless diagram
+  unless diagram
+    if section.include?("This specification does not assign an instruction encoding.")
+      unallocated_names << name
+      next
+    end
+
+    abort "#{name} has no WaveDrom encoding"
+  end
 
   mnemonic = section[/Mnemonic::\n`([^`]+)`/, 1]
   synopsis = section[/Synopsis::\n([^\n]+)/, 1].to_s.strip
@@ -69,8 +77,10 @@ instructions_source.scan(/^=== `([^`]+)`\n(.*?)(?=^=== `|\z)/m) do |name, sectio
              "R3"
            elsif by_range.fetch([19, 15])[:kind] == :operand
              "R2"
-           else
+           elsif by_range.fetch([11, 7])[:kind] == :operand
              "R1"
+           else
+             "Fixed"
            end
   category = category_by_instruction.fetch(name) do
     abort "#{name} is missing from the Chapter 2 instruction classification"
@@ -79,7 +89,7 @@ instructions_source.scan(/^=== `([^`]+)`\n(.*?)(?=^=== `|\z)/m) do |name, sectio
                mask: mask, value: match_value, format: format, category: category }
 end
 
-extra_classifications = category_by_instruction.keys - entries.map { |entry| entry[:name] }
+extra_classifications = category_by_instruction.keys - entries.map { |entry| entry[:name] } - unallocated_names
 abort "Chapter 2 classifies unknown instructions: #{extra_classifications.join(', ')}" unless extra_classifications.empty?
 
 overlaps = entries.combination(2).select do |left, right|
@@ -92,9 +102,12 @@ role = lambda do |entry, field|
   return field[:name] if field[:kind] == :operand
   case [field[:hi], field[:lo]]
   when [31, 25] then "funct7"
-  when [24, 20] then entry[:format] == "R1" ? "xfunct10[9:5]" : "xfunct5"
-  when [19, 15] then "xfunct10[4:0]"
+  when [24, 20]
+    entry[:format] == "Fixed" ? "xfunct5" :
+      (entry[:format] == "R1" ? "xfunct10[9:5]" : "xfunct5")
+  when [19, 15] then entry[:format] == "Fixed" ? "rs1" : "xfunct10[4:0]"
   when [14, 12] then "funct3"
+  when [11, 7] then entry[:format] == "Fixed" ? "rd" : "fixed"
   when [6, 0] then "opcode"
   else "fixed"
   end
@@ -143,7 +156,7 @@ html = <<~HTML
         font:14px/1.45 system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
       main { max-width:1800px; margin:auto; padding:28px; } h1 { margin:0 0 6px; font-size:28px; }
       h2 { margin:30px 0 12px; } p { color:var(--muted); } code { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; }
-      .cards { display:grid; grid-template-columns:repeat(5,minmax(130px,1fr)); gap:12px; margin:20px 0; }
+      .cards { display:grid; grid-template-columns:repeat(6,minmax(130px,1fr)); gap:12px; margin:20px 0; }
       .card { background:var(--paper); border:1px solid var(--line); border-radius:10px; padding:14px 16px; }
       .card strong { display:block; font-size:24px; } .card span { color:var(--muted); }
       .formats { display:grid; gap:10px; } .format-row { display:grid; grid-template-columns:54px 1fr; align-items:center;
@@ -159,6 +172,7 @@ html = <<~HTML
       .num { color:var(--muted); text-align:right; } .synopsis { color:var(--muted); font-size:12px; margin-top:3px; }
       .tag { display:inline-block; min-width:32px; text-align:center; padding:3px 6px; border-radius:999px; font-weight:700; }
       .tag.r3 { background:#dff4e7; color:#17653a; } .tag.r2 { background:#e5edff; color:#2b4d9d; } .tag.r1 { background:#fae9d2; color:#895315; }
+      .tag.fixed { background:#f3e6fa; color:#70418c; }
       .bitbar { display:flex; min-width:620px; height:48px; } .bit { display:flex; flex-direction:column; justify-content:center;
         text-align:center; overflow:hidden; border:1px solid; border-right:0; padding:2px 4px; white-space:nowrap; }
       .bit:first-child { border-radius:6px 0 0 6px; } .bit:last-child { border-right:1px solid; border-radius:0 6px 6px 0; }
@@ -168,7 +182,7 @@ html = <<~HTML
       footer { margin:18px 0; color:var(--muted); }
       @media print { body { background:white; } main { max-width:none; padding:10px; } .toolbar { display:none; }
         .table-wrap { overflow:visible; border:0; } table { min-width:0; font-size:9px; } th { position:static; } .bitbar { min-width:360px; height:34px; }
-        .cards { grid-template-columns:repeat(5,1fr); } }
+        .cards { grid-template-columns:repeat(6,1fr); } }
     </style>
   </head>
   <body><main>
@@ -179,12 +193,13 @@ html = <<~HTML
       <div class="card"><strong>#{format_counts.fetch('R3', 0)}</strong><span>R3 encodings</span></div>
       <div class="card"><strong>#{format_counts.fetch('R2', 0)}</strong><span>R2 encodings</span></div>
       <div class="card"><strong>#{format_counts.fetch('R1', 0)}</strong><span>R1 encodings</span></div>
+      <div class="card"><strong>#{format_counts.fetch('Fixed', 0)}</strong><span>fixed encodings</span></div>
       <div class="card"><strong>#{overlaps.length}</strong><span>decode overlaps</span></div>
     </div>
 
     <h2>Encoding formats</h2>
-    <p class="note"><b>Invariant:</b> <code>funct7[31:25]</code>, <code>funct3[14:12]</code>, and <code>opcode[6:0]</code> remain independent fields. Every instruction uses <code>funct3=000</code>; R0 is not defined.</p>
-    <p>R3 occupies <code>funct7=0x00..0x50</code> except reserved value <code>0x35</code>. R2 uses bank <code>0x51</code> with <code>xfunct5=0..31</code> except reserved value <code>0x09</code>, then continues in bank <code>0x52</code>. R1 uses bank <code>0x53</code> with <code>xfunct10=0..1</code>. The 44 <code>funct7</code> values <code>0x54..0x7f</code> remain unallocated.</p>
+    <p class="note"><b>Invariant:</b> <code>funct7[31:25]</code>, <code>funct3[14:12]</code>, and <code>opcode[6:0]</code> remain independent fields. Every instruction uses <code>funct3=000</code>.</p>
+    <p>R3 occupies <code>funct7=0x00..0x50</code> except reserved value <code>0x35</code>. R2 uses bank <code>0x51</code> with <code>xfunct5=0..31</code> except reserved value <code>0x09</code>, then continues in bank <code>0x52</code>. R1 uses bank <code>0x53</code> with <code>xfunct10=0..1</code>. The fixed, no-operand <code>ame.release</code> encoding shares the R2 <code>funct7=0x52</code> bank, using <code>xfunct5=0x0a</code> with <code>rs1=rd=0</code>; every other encoding under that selector is reserved. The 44 <code>funct7</code> values <code>0x54..0x7f</code> remain unallocated.</p>
     <div class="formats">
       <div class="format-row"><b>R3</b><div class="bitbar"><span class="bit fixed w7"><b>funct7</b><small>31:25</small></span><span class="bit operand w5"><b>src2</b><small>24:20</small></span><span class="bit operand w5"><b>src1</b><small>19:15</small></span><span class="bit fixed w3"><b>funct3=0</b><small>14:12</small></span><span class="bit operand w5"><b>dest</b><small>11:7</small></span><span class="bit fixed w7"><b>opcode</b><small>6:0</small></span></div></div>
       <div class="format-row"><b>R2</b><div class="bitbar"><span class="bit fixed w7"><b>funct7</b><small>31:25</small></span><span class="bit fixed w5"><b>xfunct5</b><small>24:20</small></span><span class="bit operand w5"><b>src1</b><small>19:15</small></span><span class="bit fixed w3"><b>funct3=0</b><small>14:12</small></span><span class="bit operand w5"><b>dest</b><small>11:7</small></span><span class="bit fixed w7"><b>opcode</b><small>6:0</small></span></div></div>
@@ -194,7 +209,7 @@ html = <<~HTML
     <h2>All instruction encodings</h2>
     <div class="toolbar">
       <input id="search" type="search" placeholder="Search instruction, mnemonic, or description">
-      <select id="format"><option value="">All formats</option><option>R3</option><option>R2</option><option>R1</option></select>
+      <select id="format"><option value="">All formats</option><option>R3</option><option>R2</option><option>R1</option><option>Fixed</option></select>
       <select id="category"><option value="">All categories</option>#{category_options}</select>
       <span id="visible"></span>
     </div>

--- a/scripts/generate-instruction-encoding-table.rb
+++ b/scripts/generate-instruction-encoding-table.rb
@@ -15,7 +15,11 @@ end
 entries = []
 File.read(instructions_path).scan(/^=== `([^`]+)`\n(.*?)(?=^=== `|\z)/m) do |name, section|
   diagram = section.lines.find { |line| line.start_with?('{"reg":') }
-  abort "#{name} has no WaveDrom encoding" unless diagram
+  unless diagram
+    next if section.include?("This specification does not assign an instruction encoding.")
+
+    abort "#{name} has no WaveDrom encoding"
+  end
 
   mnemonic = section[/Mnemonic::\n`([^`]+)`/, 1]
   abort "#{name} has no mnemonic" unless mnemonic
@@ -47,14 +51,17 @@ File.read(instructions_path).scan(/^=== `([^`]+)`\n(.*?)(?=^=== `|\z)/m) do |nam
   end
 
   abort "#{name} encoding is #{position} bits, expected 32" unless position == 32
+  dest = fields.find { |field| field[:hi] == 11 && field[:lo] == 7 }
   src1 = fields.find { |field| field[:hi] == 19 && field[:lo] == 15 }
   src2 = fields.find { |field| field[:hi] == 24 && field[:lo] == 20 }
   format = if src2[:kind] == :operand
              "R3"
            elsif src1[:kind] == :operand
              "R2"
-           else
+           elsif dest[:kind] == :operand
              "R1"
+           else
+             "Fixed"
            end
   entries << { name: name, mnemonic: mnemonic, fields: fields, mask: mask,
                value: match_value, format: format }
@@ -114,14 +121,19 @@ lines << ""
 lines << "Every encoding retains `funct7[31:25]`, `funct3[14:12]`, and " \
          "`opcode[6:0]`. R2 converts only `src2[24:20]` to `xfunct5`; R1 also " \
          "converts `src1[19:15]`, yielding `xfunct10`. All instructions use " \
-         "`funct3=000`; R0 is not defined."
+         "`funct3=000`. The no-operand `ame.release` encoding uses a reserved " \
+         "R2 selector and fixes both R2 operand fields to zero; it does not " \
+         "define another register format."
 lines << ""
-lines << "A `(funct7, funct3, opcode)` bank belongs to only one format. This rule " \
-         "prevents a more-specific R1/R2 pattern from being hidden inside an R2/R3 decode."
+lines << "A `(funct7, funct3, opcode)` bank belongs to only one register format. " \
+         "A fixed no-operand instruction may occupy a reserved selector in that " \
+         "bank when every other encoding under the selector is reserved."
 lines << "R3 uses `funct7=0x00..0x50` except the reserved value `0x35`. R2 uses " \
          "`funct7=0x51` with `xfunct5=0..31` except the reserved value `0x09`, " \
          "before continuing at `funct7=0x52`; R1 uses `funct7=0x53` with " \
-         "`xfunct10=0..1`. Values `0x54..0x7f` remain free."
+         "`xfunct10=0..1`. The fixed `ame.release` encoding shares the R2 " \
+         "`funct7=0x52` bank, using `xfunct5=0x0a` with `rs1=rd=0`. Values " \
+         "`0x54..0x7f` remain free."
 
 lines << ""
 lines << "## All instruction encodings"

--- a/src/base-isa-anchors.adoc
+++ b/src/base-isa-anchors.adoc
@@ -18,6 +18,10 @@ amestatus::
 ameudsz::
   See the RISC-V Privileged Specification for details on the `ameudsz` CSR.
 
+[#ame:doc:csr:ameown]
+ameown::
+  See <<_ameown>> for details on the `ameown` CSR.
+
 [#ame:doc:csr:ame_scalar_dtype]
 ame_scalar_dtype::
   See the RISC-V Privileged Specification for details on the `ame_scalar_dtype` CSR.
@@ -155,6 +159,10 @@ vstvec::
 [#ame:doc:csr_field:amestatus:UN]
 amestatus.UN::
   See the RISC-V Privileged Specification for details on the `amestatus.UN` field.
+
+[#ame:doc:csr_field:ameown:OWNED]
+ameown.OWNED::
+  See <<_ameown>> for details on the `ameown.OWNED` field.
 
 [#ame:doc:csr_field:henvcfg:ADUE]
 henvcfg.ADUE::

--- a/src/datatypes.adoc
+++ b/src/datatypes.adoc
@@ -205,6 +205,9 @@ implementation-defined.
 
 The AME specification represents a large state space of possible datatypes and operations.
 
+The probe sequences below assume that `MS` is enabled and the current context
+owns the AME backend.
+
 Implementations are expected to support a small fraction of the possible space.
 Because of this, AME includes a discovery mechanism for software to determine which
 datatypes, conversions, and operations are supported.

--- a/src/examples.adoc
+++ b/src/examples.adoc
@@ -21,6 +21,10 @@
 These examples implement the GEMM accumulation `C [M×P] += A [M×K] × B [K×P]`.
 AME partitions each matrix into N×N squares, where `N = sqrt(AME_NELEM)`.
 
+The examples assume that the caller has enabled `MS` and successfully acquired
+the backend. The caller releases the backend after the AME state is no longer
+needed.
+
 For a given compute datatype with element size `dtype_bits`,
 `group_size = dtype_bits / AME_UNIT_DATATYPE_SIZE` consecutive M registers hold one square.
 The A-square group starts at `m0`; the B-square group starts at `m{group_size}`.

--- a/src/functions.adoc
+++ b/src/functions.adoc
@@ -6,6 +6,59 @@
 
 
 
+[#ame:doc:func:ame_effective_ms_enabled]
+=== `ame_effective_ms_enabled` (builtin)
+Returns true when every `MS` field applicable to the current execution context
+is non-Off.
+
+|===
+h| Return Type l| Boolean
+h| Arguments   l|
+|===
+
+
+[#ame:doc:func:ame_check_state_access]
+=== `ame_check_state_access`
+Raises an illegal-instruction exception unless AME is enabled and the current
+execution context owns the backend.
+
+|===
+h| Return Type l| void
+h| Arguments   l| Bits<INSTR_ENC_SIZE> encoding
+|===
+
+[subs="specialchars,macros"]
+----
+if pass:[(]!<<ame:doc:func:ame_effective_ms_enabled,ame_effective_ms_enabled>>pass:[(]) ||
+    CSR[<<ame:doc:csr:ameown,ameown>>].OWNED == 1'b0) {
+  <<ame:doc:func:raise,raise>>pass:[(]ExceptionCode::IllegalInstruction, <<ame:doc:func:mode,mode>>pass:[(]), encoding);
+}
+----
+
+
+[#ame:doc:func:ame_acquire_backend]
+=== `ame_acquire_backend` (builtin)
+Implements the enablement check, atomic ownership request, descriptor
+validation, wait policy, response construction, initial-state binding, and
+`MS` rules defined by <<ame-backend-management-operators>>.
+
+|===
+h| Return Type l| XReg
+h| Arguments   l| XReg descriptor
+|===
+
+
+[#ame:doc:func:ame_release_backend]
+=== `ame_release_backend` (builtin)
+Implements the enablement check, completion, unbinding, ownership release, and
+`MS` rules defined by <<ame-backend-management-operators>>.
+
+|===
+h| Return Type l| void
+h| Arguments   l|
+|===
+
+
 [#ame:doc:func:ame_datatype_supported]
 === `ame_datatype_supported` (builtin)
 Returns true if dtype is a supported datatype, false otherwise.

--- a/src/glossary.adoc
+++ b/src/glossary.adoc
@@ -5,6 +5,22 @@ Accumulator Register File (ARF)::
   An <<ame:doc:param:AME_NUM_ACC_REGS,AME_NUM_ACC_REGS>>-entry register file of accumulator registers (`Acc`).
   The ARF registers hold the accumulator operand of matrix multiply instructions.
 
+AME backend::
+  The AME execution resources and architectural context state managed as one
+  ownership unit.
+
+backend ownership::
+  The exclusive binding between an AME backend and a software execution
+  context, reported by `ameown.OWNED`.
+
+effective `MS`::
+  The collective enablement state of every `MS` field applicable to the current
+  execution context. AME is enabled only when none is Off.
+
+software execution context::
+  The schedulable software state to which AME backend ownership and AME
+  architectural context state are bound.
+
 square::
   A 2-dimensional tensor (matrix) with an equal number of rows and columns.
   Squares are the fundamental unit of work in AME.

--- a/src/instruction-encoding-allocations.adoc
+++ b/src/instruction-encoding-allocations.adoc
@@ -11,11 +11,10 @@
 === Provisional encoding registry
 
 The encodings are provisional until the extension receives a stable RISC-V
-allocation.  Every instruction nevertheless has a unique decode value so
-that assemblers, decoders, and executable models can distinguish all current
-operations.
+allocation. The registry assigns a unique decode value to every AME
+instruction.
 
-All AME register instructions retain the standard R-type selector skeleton:
+All AME instructions retain the standard R-type selector skeleton:
 `funct7[31:25]`, `funct3[14:12]`, and `opcode[6:0]`.  A format with fewer
 register operands converts only the missing operand slots into extension
 function space; it does not merge or relocate the selector fields.
@@ -30,28 +29,30 @@ function space; it does not merge or relocate the selector fields.
 |===
 
 `opcode[6:0]` is `CUSTOM-1` (`0x2b`) and `funct3[14:12]` is `000` for every
-AME instruction.  R0 is not defined.  R2 adds 5 selector bits and R1 adds 10
-selector bits without changing the locations or meanings of `funct7`,
-`funct3`, or `opcode`.
+AME instruction. R2 adds 5 selector bits and R1 adds 10 without changing the
+locations or meanings of `funct7`, `funct3`, or `opcode`.
 
-One `(funct7, funct3, opcode)` bank is assigned to exactly one format.  R2
-and R1 consume their `xfunct` space densely before another `funct7` bank may
-be opened, except for explicitly reserved values.  This prevents a
-more-specific R1/R2 pattern from being hidden inside an R2/R3 decode and
-minimizes use of the shared `funct7` namespace.
+One `(funct7, funct3, opcode)` bank is assigned to one register format. A fixed
+no-operand instruction may use a reserved selector in that bank when all other
+encodings under that selector are reserved.
+
+`ame.release` is the fixed member of the Resource Management R2 bank. It uses
+`xfunct5=0x0A` with `rd=0` and `rs1=0`; every other encoding under that
+selector is reserved. This does not define an additional register format.
 
 [cols="1,1,1,2,2",options="header"]
 |===
-| Format | Instruction count | `funct7` allocation | Extension allocation | Remaining capacity
+| Allocation | Instruction count | `funct7` allocation | Selector / fixed fields | Remaining capacity
 
 | R3 | 80 | `0x00..0x50` except `0x35` | n/a | 1 reserved value
 | R2 bank 0 | 31 | `{ame-enc-r2-bank0-funct7}` | `xfunct5=0..31` except `0x09` | 1 reserved value
-| R2 bank 1 | 9 | `{ame-enc-r2-bank1-funct7}` | `xfunct5=0..8` | 23
+| R2 bank 1 | 11 | `{ame-enc-r2-bank1-funct7}` | `xfunct5=0..0x0A`; `0x0A` fixes `rs1=rd=0` | 21
 | R1 | 2 | `{ame-enc-r1-bank-funct7}` | `xfunct10=0..1` | 1022
 | Unallocated | 0 | `0x54..0x7f` | n/a | 44 `funct7` banks
 |===
 
-Within each format, operation numbers follow the order of the instruction
-categories and lists at the beginning of this chapter.  The generated
-`INSTRUCTION_ENCODINGS.md` and `INSTRUCTION_ENCODINGS.html` files contain the
-complete per-instruction `funct7`, `xfunct`, mask, and match values.
+Within each register format, operation numbers follow the order of the encoded
+instructions in the category lists at the beginning of this chapter. The
+generated `INSTRUCTION_ENCODINGS.md` and `INSTRUCTION_ENCODINGS.html` files
+contain the complete `funct7`, `xfunct`, mask, and match values for those
+instructions.

--- a/src/instructions.adoc
+++ b/src/instructions.adoc
@@ -6,7 +6,7 @@
 
 
 
-AME defines *122* instructions.
+AME defines *124* instructions.
 
 [IMPORTANT]
 ====
@@ -19,9 +19,25 @@ block shows a one-square loop or direct per-register indexing, the common rules
 are normative and supply the complete behavior for packed and wide datatypes;
 the shorthand does not restrict execution to one square or permit partial
 register-group access.
+
+Before any AME instruction other than `ame.acquire` or `ame.release` executes
+its `Operation` block, the implementation performs
+`<<ame:doc:func:ame_check_state_access,ame_check_state_access>>`. This check has
+priority over all instruction-specific validation.
 ====
 
 include::instruction-encoding-allocations.adoc[]
+
+Resource Management::
+[cols="1,2",%unbreakable]
+!===
+| Mnemonic | Name
+
+a| `ame.acquire xd, xs`
+| <<ame:doc:inst:ame_acquire,Acquire the AME backend>>
+a| `ame.release`
+| <<ame:doc:inst:ame_release,Release the AME backend>>
+!===
 
 
 Datatype Management::
@@ -344,6 +360,74 @@ a| `mreducemin.col md, ms1`
 a| `mreducemin.row md, ms1`
 | <<ame:doc:inst:mreducemin_row,Elementwise row reduce (min)>>
 !===
+
+
+<<<
+
+[#ame:doc:inst:ame_acquire]
+=== `ame.acquire`
+
+Synopsis::
+Acquire the entire AME backend
+
+Mnemonic::
+`ame.acquire xd, xs`
+
+Encoding::
++
+[IMPORTANT]
+This encoding is provisional and is not a final RISC-V allocation.
++
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": {ame-enc-funct3},"type":2},{"bits":5,"name": "xs","type":4},{"bits":5,"name": 0x9,"type":2},{"bits":7,"name": {ame-enc-r2-bank1-funct7},"type":2}]}
+....
+
+Description::
+Requests the entire AME backend; see <<ame-backend-management-operators>>.
+
+Decode Variables::
+[source,idl,subs="specialchars,macros"]
+----
+Bits<5> xd = $encoding[11:7];
+Bits<5> xs = $encoding[19:15];
+----
+
+Operation::
+[source,idl,subs="specialchars,macros"]
+----
+X[xd] = <<ame:doc:func:ame_acquire_backend,ame_acquire_backend>>pass:[(]X[xs]);
+----
+
+<<<
+
+[#ame:doc:inst:ame_release]
+=== `ame.release`
+
+Synopsis::
+Release the entire AME backend
+
+Mnemonic::
+`ame.release`
+
+Encoding::
++
+[IMPORTANT]
+This encoding is provisional and is not a final RISC-V allocation.
++
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2b,"type":2},{"bits":5,"name": 0x0,"type":2},{"bits":3,"name": {ame-enc-funct3},"type":2},{"bits":5,"name": 0x0,"type":2},{"bits":5,"name": 0xa,"type":2},{"bits":7,"name": {ame-enc-r2-bank1-funct7},"type":2}]}
+....
+
+Description::
+Releases the entire AME backend; see <<ame-backend-management-operators>>.
+
+Operation::
+[source,idl,subs="specialchars,macros"]
+----
+<<ame:doc:func:ame_release_backend,ame_release_backend>>pass:[(]);
+----
 
 
 <<<

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -11,7 +11,9 @@ Isolated::
 *  AME is designed to work well on tensor codes regardless of whether the host hart implements RISC-V Vector (RVV). Implementing RVV is not a prerequisite of AME. Frequently moving state between RVV and AME may degrade performance on some implementations.
 
 Detachable::
-*  AME is designed to allow harts to physically share an AME execution unit, and includes features to manage resource contention. Sharing execution units is an option, and many implementations may choose dedicated units.
+*  AME allows harts to share an AME backend and provides explicit ownership
+   management; see <<shared-ame-backend>>. Implementations may instead provide
+   dedicated backends.
 
 
 ===  Comparison to other RISC-V matrix extensions
@@ -41,7 +43,6 @@ h| Memory model | Weaker than RVWMO | ? | RVWMO
 Open TODO items:
 
 * Formal memory model definition
-* State management for shared AME engines
 * menvcfg options
 * Decide whether prefix and reduction operations support widening source-to-destination
   datatype tuples. If widening is supported, define the accumulator datatype, initial

--- a/src/programming_model.adoc
+++ b/src/programming_model.adoc
@@ -9,13 +9,110 @@ They are executed in program order, though follow a weaker memory model than RVW
 AME memory operations are not guaranteed to appear in program order relative to non-AME memory operations
 without an ordering fence (see TODO).
 
-TODO: AME state enablement.
+[[ame-state-enablement]]
+==== AME state enablement
+
+AME adds a two-bit matrix context status field, `MS[1:0]`, to `mstatus`.
+It is shadowed in `sstatus` and follows the `VS[1:0]` state model.
+
+.Encoding of the `MS[1:0]` status field
+[cols="1,1,3",options="header"]
+|===
+|Encoding |Status |Meaning
+
+|`0`
+|Off
+|AME state is disabled.
+
+|`1`
+|Initial
+|AME state is enabled and initial.
+
+|`2`
+|Clean
+|AME state is enabled and matches its saved image.
+
+|`3`
+|Dirty
+|AME state is enabled and might differ from its saved image.
+|===
+
+Initial, Clean, and Dirty enable AME state. An AME operation that might modify
+that state changes each applicable Initial or Clean field to Dirty unless the
+operation specifies another result. An implementation may set Dirty
+conservatively. Dirty sets the corresponding `SD` bit.
+
+Privileged software may set `MS` to Clean after saving AME state. Writing `MS`
+does not modify AME state. `MS` resets to Off; a hart without AME may make it
+read-only zero.
+
+When the hypervisor extension is present, `vsstatus` contains an `MS[1:0]`
+field. When `V=1`, both `mstatus.MS` and `vsstatus.MS` are applicable. AME is
+enabled only when every applicable field is non-Off, and state changes update
+every applicable field. A Dirty `vsstatus.MS` sets `vsstatus.SD`.
+
+[[shared-ame-backend]]
+==== Shared AME backend
+
+An AME backend contains the execution resources and architectural context
+state. It may be shared by multiple harts. Base AME exposes the entire backend
+as one indivisible ownership unit, held by at most one software execution
+context.
+
+[[ame-backend-ownership]]
+===== Ownership and access rules
+
+The read-only `ameown.OWNED` field reports whether the current context owns the
+backend. `ame.acquire` requests ownership and `ame.release` relinquishes it;
+<<ame-backend-management-operators>> defines their semantics.
+
+If any applicable `MS` field is Off:
+
+* Every AME instruction raises an illegal-instruction exception, including
+  `ame.acquire` and `ame.release`.
+* Every read or write of every AME CSR raises an illegal-instruction exception,
+  including a read of `ameown`.
+
+If every applicable `MS` field is non-Off but `ameown.OWNED=0`:
+
+* Every AME instruction other than `ame.acquire` and `ame.release` raises an
+  illegal-instruction exception.
+* Every access to a writable AME context CSR raises an illegal-instruction
+  exception.
+* Read-only capability CSRs and `ameown` may be read.
+
+These exceptions precede all other AME validation and change no AME state.
+
+If `ameown.OWNED=1`, a CSR instruction that attempts to set any applicable
+`MS` field to Off raises an illegal-instruction exception and changes no state.
+No implicit release occurs; software must execute `ame.release` first.
+
+[[ame-backend-ms]]
+===== Interaction with `MS`
+
+A newly granted backend is bound to the current context in architectural
+initial state, with `ameown.OWNED=1` and each applicable `MS` field Initial.
+Reacquiring an already-owned backend preserves its state and `MS`. Releasing
+an owned backend clears `OWNED` and sets each applicable `MS` field to Initial.
+`MS` alone does not grant ownership.
+
+[[ame-backend-context-switch]]
+===== OS context switch
+
+Software saves `ameown.OWNED` with the execution context. Before switching out
+an owner, it saves required AME state and releases the backend.
+
+To restore a saved owner, software enables `MS`, executes `ame.acquire`, and
+waits for success. It then restores any saved AME state and sets `MS` to Clean,
+or retains the initial state and Initial status established by acquisition.
+AME execution resumes only after acquisition succeeds and any required restore
+completes.
 
 === State
 
-Each hart implementing AME adds its own, private, AME registers and CSRs.
-AME instructions execute on the hart to access that state and control data transfer between AME
-registers and memory.
+An acquired AME backend binds its AME registers and writable context CSRs to
+the current software execution context. AME instructions access that state and
+control data transfer between AME registers and memory.
 
 .Register state and data movement paths for AME. The F/D and V extensions are _optional_ with AME. The only architectural datapath between vector (if present) and AME is through memory. The scalar datapath(s) is/are one-way. AME accumulator state can only be moved to/from the AME matrix registers.
 image::ame_state.svg[AME state and architectural datapaths]
@@ -374,6 +471,133 @@ AME supports six broad classes of arithmetic and/or logical operators:
 *  Load/store
 
 AME does not support general masking/predication on computational instructions, though a future extension may add support.
+
+[[ame-backend-management-operators]]
+==== Backend management
+
+===== `ame.acquire`
+
+`ame.acquire xd, xs` atomically requests the entire backend. Every applicable
+`MS` field must be non-Off; otherwise, the instruction raises an
+illegal-instruction exception.
+
+`xs` contains the acquisition descriptor:
+
+[cols="1,1,3",options="header"]
+|===
+|Field |Location |Description
+
+|WAIT_MODE
+|`1:0`
+|Waiting policy
+
+|TIMEOUT_CLASS
+|`5:2`
+|Bounded-wait class
+
+|RESERVED
+|`XLEN-1:6`
+|Must be zero
+|===
+
+`WAIT_MODE=0b00` is TRY and does not wait. `WAIT_MODE=0b01` is BOUNDED_WAIT
+and waits for a finite, implementation-defined interval. Other encodings are
+reserved. For BOUNDED_WAIT, `TIMEOUT_CLASS` values `0x0` through `0x3` select
+SHORT, MEDIUM, LONG, and VERY_LONG; `0xF` is implementation-defined and all
+other values are reserved. TRY ignores `TIMEOUT_CLASS`.
+
+`xd` receives:
+
+[cols="1,1,3",options="header"]
+|===
+|Field |Location |Description
+
+|SUCCESS
+|`0`
+|One on success; zero on failure
+
+|STATUS
+|`7:1`
+|Acquisition status
+
+|RESERVED
+|`XLEN-1:8`
+|Zero
+|===
+
+[cols="1,2,1,4",options="header",%unbreakable]
+|===
+|STATUS |Name |SUCCESS |Description
+
+|`0x00`
+|GRANTED
+|1
+|Granted or already owned
+
+|`0x01`
+|BUSY
+|0
+|Backend unavailable
+
+|`0x02`
+|UNSUPPORTED
+|0
+|No accessible AME backend
+
+|`0x03`
+|DISABLED
+|0
+|Disabled by implementation or platform configuration
+
+|`0x04`
+|BAD_DESC
+|0
+|Invalid descriptor
+
+|`0x05`
+|TIMEOUT
+|0
+|Bounded wait expired
+
+|`0x06`
+|INTERRUPTED
+|0
+|Wait interrupted
+
+|`0x07`
+|DENIED
+|0
+|Denied by platform policy
+
+|`0x08-0x7E`
+|RESERVED
+|-
+|Reserved
+
+|`0x7F`
+|IMPL_DEFINED
+|Impl.
+|Implementation-defined result
+|===
+
+An invalid descriptor returns BAD_DESC, and disabled configuration returns
+DISABLED. A request from the current owner returns GRANTED without changing
+the bound state or `MS`. A new grant atomically binds architectural initial
+state, sets `ameown.OWNED` to one, and sets each applicable `MS` field to
+Initial. Initial state has zero-valued `M` and `Acc` registers, zero-valued
+`Md` and `Ad` descriptors, and reset-valued writable AME CSRs. Failure changes
+neither backend binding, `ameown`, nor `MS`.
+
+===== `ame.release`
+
+`ame.release` requires every applicable `MS` field to be non-Off. If the
+current context owns the backend, it stops accepting new operations, drains
+retired operations and earlier state-save stores, unbinds the state, and
+atomically releases ownership.
+
+After release, `ameown.OWNED` is zero and each applicable `MS` field is
+Initial. If the current context is not the owner, the instruction is a no-op
+that preserves `MS`.
 
 
 

--- a/src/state.adoc
+++ b/src/state.adoc
@@ -2,7 +2,7 @@
 == AME State
 :imagesdir: ../images
 
-To each hart, AME adds
+AME architectural state includes
 
 * <<ame:doc:param:AME_NUM_M_REGS,AME_NUM_M_REGS>> general-purpose matrix registers (`M`)
 * <<ame:doc:param:AME_NUM_M_REGS,AME_NUM_M_REGS>> datatype registers for the general-purpose registers (`Md`)
@@ -104,7 +104,7 @@ The encoding format of `Ad` datatypes is identical to the format for `Md`, and i
 
 === Control and status registers (CSRs)
 
-AME adds four CSRs.
+AME adds five CSRs.
 
 The addresses below are provisional allocations in the corresponding
 user-level custom read/write and read-only CSR ranges.  A future ratified
@@ -125,11 +125,44 @@ version may assign different standard CSR addresses.
 | `CC2`
 | Datatype of data scalar operands supplied in `X` registers
 
+| <<ame:doc:csr:ameown,ameown>>
+| `CC3`
+| Ownership of the AME backend
+
 | <<ame:doc:csr:amestatus,amestatus>>
 | `800`
 | Status of the AME extension
 
 |===
+
+`ame_scalar_dtype` and `amestatus` are backend context state. `amenlen` and
+`ameudsz` report implementation capabilities. `ameown` reports ownership.
+
+==== ameown
+
+`ameown` is a read-only CSR that reports whether the current software execution
+context owns the entire AME backend. It may be read when every applicable `MS`
+field is non-Off, regardless of ownership. Any CSR instruction that attempts
+to write `ameown` raises an illegal-instruction exception.
+
+|===
+| Field | Location | Description
+
+| OWNED
+| `0`
+| One when the current context owns the backend; zero otherwise
+
+| RESERVED
+| `XLEN-1:1`
+| Reads as zero
+
+|===
+
+`ameown.OWNED` is set when `ame.acquire` newly grants ownership and cleared by
+`ame.release`. A failed acquire does not change it. It resets to zero.
+Software saves `ameown.OWNED` with the execution context. To restore a saved
+value of one, software executes `ame.acquire`; a successful acquisition
+restores `ameown.OWNED` to one.
 
 ==== ame_scalar_dtype
 
@@ -145,8 +178,8 @@ This CSR does not apply to fixed-type control operands.  Shift amounts,
 indices, offsets, and other instruction-defined control values retain their
 fixed integer semantics and do not read this CSR.
 
-The CSR resets to zero.  It is hart state and must be saved and restored with
-the AME state when software changes execution context.
+The CSR resets to zero. It is backend context state and must be saved and
+restored with the AME state when software changes execution context.
 
 |===
 | Field | Location | Description
@@ -212,7 +245,8 @@ without hardcoding any implementation-specific constant.
 
 ==== amestatus
 
-`amestatus` reports sticky AME execution status.  It resets to zero.  Software
+`amestatus` is backend context state and reports sticky AME execution status.
+It resets to zero. Software
 clears a reported condition by writing zero to the corresponding bit; writing
 one leaves that bit set.  Reserved bits are WPRI and read as zero.
 


### PR DESCRIPTION
## Summary

- define `MS[1:0]` enablement and Off/Initial/Clean/Dirty state tracking
- define the entire AME backend as one indivisible ownership unit
- add the read-only `ameown.OWNED` CSR and its context-switch behavior
- define ownership/access rules and the interaction between `MS` and backend ownership
- define `ame.acquire` and `ame.release` descriptors, responses, state transitions, and OS restore flow
- add provisional encodings for both instructions in the Resource Management R2 bank
- remove the completed AME state-enablement and shared-engine state-management TODOs
- replace the per-hart private-state assumption with backend context-state binding

## Provisional encodings

- `ame.acquire`: `funct7=0x52`, `xfunct5=0x09`, with `rs1` and `rd`
- `ame.release`: `funct7=0x52`, `xfunct5=0x0A`, `rs1=rd=0` (`0xA4A0002B`)
- all other encodings under the `ame.release` selector remain reserved

## Validation

- built the complete 387-page PDF with AsciiDoc warnings treated as failures
- checked all 124 instruction encodings for duplicates and decode-space overlaps
- checked instruction semantics, legacy names, managed operations, and internal cross-references
- verified the generated Markdown and HTML encoding catalogs at 124 entries
- rendered and visually inspected the `MS`, shared-backend, `ameown`, encoding-registry, `ame.acquire`, and `ame.release` pages
