### PR TITLE
Generalize mconv.ew; redefine zip/unzip destinations as D0/D1 operands; drop packed from Permutation

### DIFF
--- a/INSTRUCTION_ENCODINGS.html
+++ b/INSTRUCTION_ENCODINGS.html
@@ -45,8 +45,8 @@
   <p>Standalone review artifact generated from <code>src/instructions.adoc</code>. Decoder rule: <code>(word &amp; mask) == match</code>.</p>
   <div class="cards">
     <div class="card"><strong>141</strong><span>instructions</span></div>
-    <div class="card"><strong>94</strong><span>R3 encodings</span></div>
-    <div class="card"><strong>41</strong><span>R2 encodings</span></div>
+    <div class="card"><strong>97</strong><span>R3 encodings</span></div>
+    <div class="card"><strong>38</strong><span>R2 encodings</span></div>
     <div class="card"><strong>5</strong><span>R1 encodings</span></div>
     <div class="card"><strong>1</strong><span>fixed encodings</span></div>
     <div class="card"><strong>0</strong><span>decode overlaps</span></div>
@@ -946,32 +946,50 @@
 <tr data-format="R3" data-category="Permutation">
     <td class="num">98</td>
     <td><span class="tag r3">R3</span></td>
+    <td><code>mcolscatadd.ew</code></td>
+    <td><code>mcolscatadd.ew md, ms1, ms2</code><div class="synopsis">Elementwise column scatter-add</div></td>
+    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x3a</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
+    <td><code>0xfe00707f</code></td>
+    <td><code>0x7400002b</code></td>
+  </tr>
+<tr data-format="R3" data-category="Permutation">
+    <td class="num">99</td>
+    <td><span class="tag r3">R3</span></td>
+    <td><code>mcolscatmax.ew</code></td>
+    <td><code>mcolscatmax.ew md, ms1, ms2</code><div class="synopsis">Elementwise column scatter-max</div></td>
+    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x3c</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
+    <td><code>0xfe00707f</code></td>
+    <td><code>0x7800002b</code></td>
+  </tr>
+<tr data-format="R3" data-category="Permutation">
+    <td class="num">100</td>
+    <td><span class="tag r3">R3</span></td>
     <td><code>mcolshift.ew.x</code></td>
     <td><code>mcolshift.ew.x md, ms1, xs1</code><div class="synopsis">Elementwise column shift by scalar offset</div></td>
     <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x34</small></span><span class="bit operand w5" title="bits 24:20"><b>xs1</b><small>xs1</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
     <td><code>0xfe00707f</code></td>
     <td><code>0x6800002b</code></td>
   </tr>
-<tr data-format="R2" data-category="Permutation">
-    <td class="num">99</td>
-    <td><span class="tag r2">R2</span></td>
-    <td><code>mcolunzip.ew</code></td>
-    <td><code>mcolunzip.ew md, ms1</code><div class="synopsis">Elementwise column unzip (de-interleave)</div></td>
-    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x51</small></span><span class="bit fixed w5" title="bits 24:20"><b>xfunct5</b><small>0xa</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
-    <td><code>0xfff0707f</code></td>
-    <td><code>0xa2a0002b</code></td>
-  </tr>
-<tr data-format="R2" data-category="Permutation">
-    <td class="num">100</td>
-    <td><span class="tag r2">R2</span></td>
-    <td><code>mcolzip.ew</code></td>
-    <td><code>mcolzip.ew md, ms1</code><div class="synopsis">Elementwise column zip (interleave)</div></td>
-    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x51</small></span><span class="bit fixed w5" title="bits 24:20"><b>xfunct5</b><small>0xb</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
-    <td><code>0xfff0707f</code></td>
-    <td><code>0xa2b0002b</code></td>
-  </tr>
 <tr data-format="R3" data-category="Permutation">
     <td class="num">101</td>
+    <td><span class="tag r3">R3</span></td>
+    <td><code>mcolunzip.ew</code></td>
+    <td><code>mcolunzip.ew md, ms1, ms2</code><div class="synopsis">Column unzip (de-interleave columns from two inputs)</div></td>
+    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x61</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
+    <td><code>0xfe00707f</code></td>
+    <td><code>0xc200002b</code></td>
+  </tr>
+<tr data-format="R3" data-category="Permutation">
+    <td class="num">102</td>
+    <td><span class="tag r3">R3</span></td>
+    <td><code>mcolzip.ew</code></td>
+    <td><code>mcolzip.ew md, ms1, ms2</code><div class="synopsis">Column zip (interleave columns from two inputs)</div></td>
+    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x62</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
+    <td><code>0xfe00707f</code></td>
+    <td><code>0xc400002b</code></td>
+  </tr>
+<tr data-format="R3" data-category="Permutation">
+    <td class="num">103</td>
     <td><span class="tag r3">R3</span></td>
     <td><code>mrowbcast.ew.x</code></td>
     <td><code>mrowbcast.ew.x md, ms1, xs1</code><div class="synopsis">Broadcast one row to all rows</div></td>
@@ -980,7 +998,7 @@
     <td><code>0x6a00002b</code></td>
   </tr>
 <tr data-format="R3" data-category="Permutation">
-    <td class="num">102</td>
+    <td class="num">104</td>
     <td><span class="tag r3">R3</span></td>
     <td><code>mrowgather.ew</code></td>
     <td><code>mrowgather.ew md, ms1, ms2</code><div class="synopsis">Elementwise row gather (take)</div></td>
@@ -989,7 +1007,25 @@
     <td><code>0x6c00002b</code></td>
   </tr>
 <tr data-format="R3" data-category="Permutation">
-    <td class="num">103</td>
+    <td class="num">105</td>
+    <td><span class="tag r3">R3</span></td>
+    <td><code>mrowscatadd.ew</code></td>
+    <td><code>mrowscatadd.ew md, ms1, ms2</code><div class="synopsis">Elementwise row scatter-add</div></td>
+    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x39</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
+    <td><code>0xfe00707f</code></td>
+    <td><code>0x7200002b</code></td>
+  </tr>
+<tr data-format="R3" data-category="Permutation">
+    <td class="num">106</td>
+    <td><span class="tag r3">R3</span></td>
+    <td><code>mrowscatmax.ew</code></td>
+    <td><code>mrowscatmax.ew md, ms1, ms2</code><div class="synopsis">Elementwise row scatter-max</div></td>
+    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x3b</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
+    <td><code>0xfe00707f</code></td>
+    <td><code>0x7600002b</code></td>
+  </tr>
+<tr data-format="R3" data-category="Permutation">
+    <td class="num">107</td>
     <td><span class="tag r3">R3</span></td>
     <td><code>mrowshift.ew.x</code></td>
     <td><code>mrowshift.ew.x md, ms1, xs1</code><div class="synopsis">Elementwise row shift by scalar offset</div></td>
@@ -997,59 +1033,23 @@
     <td><code>0xfe00707f</code></td>
     <td><code>0x6e00002b</code></td>
   </tr>
-<tr data-format="R2" data-category="Permutation">
-    <td class="num">104</td>
-    <td><span class="tag r2">R2</span></td>
+<tr data-format="R3" data-category="Permutation">
+    <td class="num">108</td>
+    <td><span class="tag r3">R3</span></td>
     <td><code>mrowunzip.ew</code></td>
-    <td><code>mrowunzip.ew md, ms1</code><div class="synopsis">Row unzip (de-interleave rows)</div></td>
-    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x51</small></span><span class="bit fixed w5" title="bits 24:20"><b>xfunct5</b><small>0xc</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
-    <td><code>0xfff0707f</code></td>
-    <td><code>0xa2c0002b</code></td>
+    <td><code>mrowunzip.ew md, ms1, ms2</code><div class="synopsis">Row unzip (de-interleave rows from two inputs)</div></td>
+    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x63</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
+    <td><code>0xfe00707f</code></td>
+    <td><code>0xc600002b</code></td>
   </tr>
 <tr data-format="R3" data-category="Permutation">
-    <td class="num">105</td>
+    <td class="num">109</td>
     <td><span class="tag r3">R3</span></td>
     <td><code>mrowzip.ew</code></td>
     <td><code>mrowzip.ew md, ms1, ms2</code><div class="synopsis">Row zip (interleave rows from two inputs)</div></td>
     <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x38</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
     <td><code>0xfe00707f</code></td>
     <td><code>0x7000002b</code></td>
-  </tr>
-<tr data-format="R3" data-category="Permutation">
-    <td class="num">106</td>
-    <td><span class="tag r3">R3</span></td>
-    <td><code>mscatadd.col</code></td>
-    <td><code>mscatadd.col md, ms1, ms2</code><div class="synopsis">Elementwise column scatter-add</div></td>
-    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x39</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
-    <td><code>0xfe00707f</code></td>
-    <td><code>0x7200002b</code></td>
-  </tr>
-<tr data-format="R3" data-category="Permutation">
-    <td class="num">107</td>
-    <td><span class="tag r3">R3</span></td>
-    <td><code>mscatadd.row</code></td>
-    <td><code>mscatadd.row md, ms1, ms2</code><div class="synopsis">Elementwise scatter-add</div></td>
-    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x3a</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
-    <td><code>0xfe00707f</code></td>
-    <td><code>0x7400002b</code></td>
-  </tr>
-<tr data-format="R3" data-category="Permutation">
-    <td class="num">108</td>
-    <td><span class="tag r3">R3</span></td>
-    <td><code>mscatmax.col</code></td>
-    <td><code>mscatmax.col md, ms1, ms2</code><div class="synopsis">Elementwise column scatter-max</div></td>
-    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x3b</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
-    <td><code>0xfe00707f</code></td>
-    <td><code>0x7600002b</code></td>
-  </tr>
-<tr data-format="R3" data-category="Permutation">
-    <td class="num">109</td>
-    <td><span class="tag r3">R3</span></td>
-    <td><code>mscatmax.row</code></td>
-    <td><code>mscatmax.row md, ms1, ms2</code><div class="synopsis">Elementwise scatter-max</div></td>
-    <td><div class="bitbar"><span class="bit fixed w7" title="bits 31:25"><b>funct7</b><small>0x3c</small></span><span class="bit operand w5" title="bits 24:20"><b>ms2</b><small>ms2</small></span><span class="bit operand w5" title="bits 19:15"><b>ms1</b><small>ms1</small></span><span class="bit fixed w3" title="bits 14:12"><b>funct3</b><small>0x0</small></span><span class="bit operand w5" title="bits 11:7"><b>md</b><small>md</small></span><span class="bit fixed w7" title="bits 6:0"><b>opcode</b><small>0x2b</small></span></div></td>
-    <td><code>0xfe00707f</code></td>
-    <td><code>0x7800002b</code></td>
   </tr>
 <tr data-format="R2" data-category="Reduction">
     <td class="num">110</td>

--- a/INSTRUCTION_ENCODINGS.md
+++ b/INSTRUCTION_ENCODINGS.md
@@ -11,8 +11,8 @@ The canonical decoder test is `(instruction_word & mask) == match`. Fixed fields
 | Instructions | 141 |
 | Fixed encodings | 1 |
 | R1 encodings | 5 |
-| R2 encodings | 41 |
-| R3 encodings | 94 |
+| R2 encodings | 38 |
+| R3 encodings | 97 |
 | Exact duplicate decode patterns | 0 |
 | Partial decode-space overlaps | 0 |
 
@@ -50,8 +50,8 @@ R3 uses `funct7=0x00..0x50` and `funct7=0x54..0x60`. R2 uses `funct7=0x51` with 
 | 21 | R3 | `mcolgather.ew` | `mcolgather.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x33`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6600002b` |
 | 22 | R1 | `mcolid.ew` | `mcolid.ew md` | `md[11:7]` | `[31:25]=0x53` (`ame-enc-r1-bank-funct7`); `[24:20]=0x00`; `[19:15]=0x02`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfffff07f` | `0xa601002b` |
 | 23 | R3 | `mcolshift.ew.x` | `mcolshift.ew.x md, ms1, xs1` | `xs1[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x34`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6800002b` |
-| 24 | R2 | `mcolunzip.ew` | `mcolunzip.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2a0002b` |
-| 25 | R2 | `mcolzip.ew` | `mcolzip.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2b0002b` |
+| 24 | R3 | `mcolunzip.ew` | `mcolunzip.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x61`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0xc200002b` |
+| 25 | R3 | `mcolzip.ew` | `mcolzip.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x62`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0xc400002b` |
 | 26 | R2 | `mconv.ew` | `mconv.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0d`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2d0002b` |
 | 27 | R3 | `mbcast.m.x` | `mbcast.m.x md, xs1, xtyp` | `xtyp[24:20]`; `xs1[19:15]`; `md[11:7]` | `[31:25]=0x58`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0xb000002b` |
 | 28 | R2 | `mcos.ew` | `mcos.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0e`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2e0002b` |
@@ -134,13 +134,13 @@ R3 uses `funct7=0x00..0x50` and `funct7=0x54..0x60`. R2 uses `funct7=0x51` with 
 | 105 | R3 | `mrowgather.ew` | `mrowgather.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x36`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6c00002b` |
 | 106 | R1 | `mrowid.ew` | `mrowid.ew md` | `md[11:7]` | `[31:25]=0x53` (`ame-enc-r1-bank-funct7`); `[24:20]=0x00`; `[19:15]=0x03`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfffff07f` | `0xa601802b` |
 | 107 | R3 | `mrowshift.ew.x` | `mrowshift.ew.x md, ms1, xs1` | `xs1[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x37`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6e00002b` |
-| 108 | R2 | `mrowunzip.ew` | `mrowunzip.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x0c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa2c0002b` |
+| 108 | R3 | `mrowunzip.ew` | `mrowunzip.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x63`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0xc600002b` |
 | 109 | R3 | `mrowzip.ew` | `mrowzip.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x38`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7000002b` |
 | 110 | R2 | `mrsqrt.ew` | `mrsqrt.ew md, ms1` | `ms1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x12`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa320002b` |
-| 111 | R3 | `mscatadd.col` | `mscatadd.col md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x39`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7200002b` |
-| 112 | R3 | `mscatadd.row` | `mscatadd.row md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7400002b` |
-| 113 | R3 | `mscatmax.col` | `mscatmax.col md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7600002b` |
-| 114 | R3 | `mscatmax.row` | `mscatmax.row md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7800002b` |
+| 111 | R3 | `mrowscatadd.ew` | `mrowscatadd.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x39`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7200002b` |
+| 112 | R3 | `mcolscatadd.ew` | `mcolscatadd.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3a`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7400002b` |
+| 113 | R3 | `mrowscatmax.ew` | `mrowscatmax.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3b`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7600002b` |
+| 114 | R3 | `mcolscatmax.ew` | `mcolscatmax.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x3c`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x7800002b` |
 | 115 | R3 | `mselge.ew` | `mselge.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x30`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6000002b` |
 | 116 | R3 | `msellt.ew` | `msellt.ew md, ms1, ms2` | `ms2[24:20]`; `ms1[19:15]`; `md[11:7]` | `[31:25]=0x31`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfe00707f` | `0x6200002b` |
 | 117 | R2 | `msettyp` | `msettyp md, xs1` | `xs1[19:15]`; `md[11:7]` | `[31:25]=0x51` (`ame-enc-r2-bank0-funct7`); `[24:20]=0x03`; `[14:12]=0x0` (`ame-enc-funct3`); `[6:0]=0x2b` | `0xfff0707f` | `0xa230002b` |

--- a/docs/migration/ame-prose-migration-audit.md
+++ b/docs/migration/ame-prose-migration-audit.md
@@ -31,8 +31,8 @@ The published prose is authoritative after cutover. NumPy examples are never sem
 | `mcolgather.ew` | 2122 | `ame:doc:inst:mcolgather_ew` | Permutation | `mcolgather.ew md, ms1, ms2` | `D[i,j] = A[i, B[i,j]]` | `ame-common-structural` | - | Ready |
 | `mcolid.ew` | 2240 | `ame:doc:inst:mcolid_ew` | State Management | `mcolid.ew md` | `D[i,j] = j` | `ame-common-register-groups` | - | Ready |
 | `mcolshift.ew.x` | 2323 | `ame:doc:inst:mcolshift_ew_x` | Permutation | `mcolshift.ew.x md, ms1, xs1` | `D[i,j] = A[i, j+c]` | `ame-common-structural` | - | Ready |
-| `mcolunzip.ew` | 2437 | `ame:doc:inst:mcolunzip_ew` | Permutation | `mcolunzip.ew md, ms1` | `D[i,j] = A[i,2j] + D[i, N/2+j] = A[i,2j+1]` | `ame-common-structural` | - | Ready |
-| `mcolzip.ew` | 2535 | `ame:doc:inst:mcolzip_ew` | Permutation | `mcolzip.ew md, ms1` | `D[i,2j] = A[i,j] + D[i,2j+1] = A[i, N/2+j]` | `ame-common-structural` | - | Ready |
+| `mcolunzip.ew` | 2437 | `ame:doc:inst:mcolunzip_ew` | Permutation | `mcolunzip.ew md, ms1, ms2` | `D^0^[i,j] = A[i,2j] + D^0^[i, N/2+j] = B[i,2j] + D^1^[i,j] = A[i,2j+1] + D^1^[i, N/2+j] = B[i,2j+1]` | `ame-common-structural` | - | Ready |
+| `mcolzip.ew` | 2535 | `ame:doc:inst:mcolzip_ew` | Permutation | `mcolzip.ew md, ms1, ms2` | `D^0^[i,2j] = A[i,j] + D^0^[i,2j+1] = B[i,j] + D^1^[i,2j] = A[i, N/2+j] + D^1^[i,2j+1] = B[i, N/2+j]` | `ame-common-structural` | - | Ready |
 | `mconv.ew` | 2636 | `ame:doc:inst:mconv_ew` | Register move / data conversion | `mconv.ew md, ms1` | `D = convert(A) over the formed logical operand` | `ame-common-register-groups` | - | Ready |
 | `mbcast.m.x` | 2755 | `ame:doc:inst:mbcast_m_x` | Register move / data conversion | `mbcast.m.x md, xs1, xtyp` | `D[i] = CONV1D(X[xs1], X[xtyp], Md[md])` | `ame-common-register-groups` | - | Ready |
 | `mcos.ew` | 2835 | `ame:doc:inst:mcos_ew` | Elementwise Math Functions | `mcos.ew md, ms1` | `D[i] = cos(A[i])` | `ame-common-arithmetic` | - | Ready |
@@ -115,13 +115,13 @@ The published prose is authoritative after cutover. NumPy examples are never sem
 | `mrowgather.ew` | 10206 | `ame:doc:inst:mrowgather_ew` | Permutation | `mrowgather.ew md, ms1, ms2` | `D[i,j] = A[B[i,j],j]` | `ame-common-structural` | - | Ready |
 | `mrowid.ew` | 10324 | `ame:doc:inst:mrowid_ew` | State Management | `mrowid.ew md` | `D[i,j] = i` | `ame-common-register-groups` | - | Ready |
 | `mrowshift.ew.x` | 10407 | `ame:doc:inst:mrowshift_ew_x` | Permutation | `mrowshift.ew.x md, ms1, xs1` | `D[i,j] = A[i+c,j]` | `ame-common-structural` | - | Ready |
-| `mrowunzip.ew` | 10518 | `ame:doc:inst:mrowunzip_ew` | Permutation | `mrowunzip.ew md, ms1` | `D^0^[i,:] = A[2i,:] + D^1^[i,:] = A[2i+1,:]` | `ame-common-structural` | AME-MIG-004 | Ready |
-| `mrowzip.ew` | 10629 | `ame:doc:inst:mrowzip_ew` | Permutation | `mrowzip.ew md, ms1, ms2` | `D[2i,:] = A[i,:] + D[2i+1,:] = B[i,:]` | `ame-common-structural` | AME-MIG-004 | Ready |
+| `mrowunzip.ew` | 10518 | `ame:doc:inst:mrowunzip_ew` | Permutation | `mrowunzip.ew md, ms1, ms2` | `D^0^[k,j] = A[2k,j] + D^0^[k+N/2,j] = B[2k,j] + D^1^[k,j] = A[2k+1,j] + D^1^[k+N/2,j] = B[2k+1,j]` | `ame-common-structural` | AME-MIG-004 | Ready |
+| `mrowzip.ew` | 10629 | `ame:doc:inst:mrowzip_ew` | Permutation | `mrowzip.ew md, ms1, ms2` | `D^0^[2k,j] = A[k,j] + D^0^[2k+1,j] = B[k,j] + D^1^[2k,j] = A[N/2+k,j] + D^1^[2k+1,j] = B[N/2+k,j]` | `ame-common-structural` | AME-MIG-004 | Ready |
 | `mrsqrt.ew` | 10756 | `ame:doc:inst:mrsqrt_ew` | Elementwise Math Functions | `mrsqrt.ew md, ms1` | `D[i] = 1 / sqrt(A[i])` | `ame-common-arithmetic` | - | Ready |
-| `mscatadd.col` | 10851 | `ame:doc:inst:mscatadd_col` | Permutation | `mscatadd.col md, ms1, ms2` | `D[B[i,j], j] += A[i,j]` | `ame-common-structural` | - | Ready |
-| `mscatadd.row` | 10970 | `ame:doc:inst:mscatadd_row` | Permutation | `mscatadd.row md, ms1, ms2` | `D[i, B[i,j]] += A[i,j]` | `ame-common-structural` | - | Ready |
-| `mscatmax.col` | 11089 | `ame:doc:inst:mscatmax_col` | Permutation | `mscatmax.col md, ms1, ms2` | `D[B[i,j], j] = max(D[B[i,j],j], A[i,j])` | `ame-common-structural` | - | Ready |
-| `mscatmax.row` | 11208 | `ame:doc:inst:mscatmax_row` | Permutation | `mscatmax.row md, ms1, ms2` | `D[i, B[i,j]] = max(D[i,B[i,j]], A[i,j])` | `ame-common-structural` | - | Ready |
+| `mrowscatadd.ew` | 10851 | `ame:doc:inst:mrowscatadd_ew` | Permutation | `mrowscatadd.ew md, ms1, ms2` | `D[B[i,j], j] += A[i,j]` | `ame-common-structural` | - | Ready |
+| `mcolscatadd.ew` | 10970 | `ame:doc:inst:mcolscatadd_ew` | Permutation | `mcolscatadd.ew md, ms1, ms2` | `D[i, B[i,j]] += A[i,j]` | `ame-common-structural` | - | Ready |
+| `mrowscatmax.ew` | 11089 | `ame:doc:inst:mrowscatmax_ew` | Permutation | `mrowscatmax.ew md, ms1, ms2` | `D[B[i,j], j] = max(D[B[i,j],j], A[i,j])` | `ame-common-structural` | - | Ready |
+| `mcolscatmax.ew` | 11208 | `ame:doc:inst:mcolscatmax_ew` | Permutation | `mcolscatmax.ew md, ms1, ms2` | `D[i, B[i,j]] = max(D[i,B[i,j]], A[i,j])` | `ame-common-structural` | - | Ready |
 | `mselge.ew` | 11327 | `ame:doc:inst:mselge_ew` | Compare and Predication | `mselge.ew md, ms1, ms2` | `D[i] = (A[i] >= 0) ? B[i] : 0` | `ame-common-arithmetic` | - | Ready |
 | `msellt.ew` | 11433 | `ame:doc:inst:msellt_ew` | Compare and Predication | `msellt.ew md, ms1, ms2` | `D[i] = (A[i] < 0) ? B[i] : 0` | `ame-common-arithmetic` | - | Ready |
 | `msettyp` | 11539 | `ame:doc:inst:msettyp` | Datatype Management | `msettyp md, xs1` | `new_dtype = X[xs1][31:0]; Md[md] = new_dtype; raw_bits(M[md .. md+group_size-1]) = 0` | `ame-common-datatype-support` | - | Ready |
@@ -288,9 +288,9 @@ The published prose is authoritative after cutover. NumPy examples are never sem
 ### AME-MIG-004: row zip/unzip wide-tuple ambiguity
 
 - Before: the legacy prose and IDL name literal consecutive bases (`base`, `base+1`) for the two squares, while the same IDL permits operation support to be queried for a wide datatype whose square occupies a multi-register aligned group.  The derived `base+1` then overlaps the first wide group and cannot itself satisfy that group's alignment.
-- After: `mrowzip.ew` and `mrowunzip.ew` support only datatypes no wider than `AME_UNIT_DATATYPE_SIZE`.  Unit datatypes use the literal register pair; packed datatypes use slot 0 of each literal register and preserve the other destination slots.
-- Evidence: this retains the literal register selection and element loop of the legacy instruction definitions for every supported case, while excluding the internally contradictory wide case.
-- Architectural impact: an implementation cannot advertise row zip/unzip support for a wide datatype.  A future revision may define a distinct wide encoding or group-stride rule.
+- After: the two destination squares are defined as matrix operands `D0` and `D1` rather than literal registers: `D0` is the logical square at `md`, and `D1` occupies the consecutive M registers immediately following `D0`, so a wide datatype whose square spans `ceil(sizeof(dtype)/AME_UNIT_DATATYPE_SIZE)` registers makes the pair span twice that many consecutive registers starting at `md`, and `md` must be aligned to that combined span.  Packed datatypes are no longer supported by the zip/unzip family; every Permutation instruction requires a datatype no smaller than `AME_UNIT_DATATYPE_SIZE`, so a unit datatype uses the literal register pair.
+- Evidence: this retains the element loop of the legacy instruction definitions for every supported case and resolves the internally contradictory wide case by generalizing the destination naming instead of excluding it.
+- Architectural impact: an implementation may advertise zip/unzip support for wide datatypes; the second destination square then starts `ceil(sizeof(dtype)/AME_UNIT_DATATYPE_SIZE)` registers after `md` instead of at `md+1`.  Packed datatypes, previously mapped to slot 0 of the literal registers, now raise the unsupported-operation contract instead.
 
 ### AME-MIG-005: transposed matrix formation when `N_sq > 1`
 

--- a/ref/ame-instruction-baseline.json
+++ b/ref/ame-instruction-baseline.json
@@ -10,12 +10,12 @@
       "synopsis": "Acquire the entire AME backend",
       "mnemonic": "ame.acquire xd, xs",
       "description": "Requests the entire AME backend; see <<ame-backend-management-operators>>.",
+      "operation": "X[xd] = acquire_backend(descriptor = X[xs])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"xd\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs\",\"type\":4},{\"bits\":5,\"name\": 0x9,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank1-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"xd\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs\",\"type\":4},{\"bits\":5,\"name\": 0x9,\"type\":2},{\"bits\":7,\"name\": 0x52,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa490002b",
-      "operation": "X[xd] = acquire_backend(descriptor = X[xs])"
+      "match": "0xa490002b"
     },
     {
       "order": 2,
@@ -25,12 +25,12 @@
       "synopsis": "Release the entire AME backend",
       "mnemonic": "ame.release",
       "description": "Releases the entire AME backend; see <<ame-backend-management-operators>>.",
+      "operation": "release the backend held by this hart",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0xa,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank1-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0xa,\"type\":2},{\"bits\":7,\"name\": 0x52,\"type\":2}]}",
       "format": "Fixed",
       "mask": "0xffffffff",
-      "match": "0xa4a0002b",
-      "operation": "release the backend held by this hart"
+      "match": "0xa4a0002b"
     },
     {
       "order": 3,
@@ -40,12 +40,12 @@
       "synopsis": "Get accumulator datatype",
       "mnemonic": "agettyp xd, ad",
       "description": "Gets the 32-bit datatype descriptor of an `Acc` register by reading from `Ad`\nand zero-extending it to XLEN in `X[xd]`.",
+      "operation": "X[xd] = zero_extend_XLEN(Ad[ad])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"xd\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ad\",\"type\":4},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"xd\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ad\",\"type\":4},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa200002b",
-      "operation": "X[xd] = zero_extend_XLEN(Ad[ad])"
+      "match": "0xa200002b"
     },
     {
       "order": 4,
@@ -55,12 +55,12 @@
       "synopsis": "Set accumulator datatype",
       "mnemonic": "asettyp ad, xs1",
       "description": "Sets the datatype of an `Acc` register and clears every physical storage bit of\nthe accumulator to zero.  This is a raw-bit clear, not conversion to the new\ndatatype's semantic zero.  The new 32-bit descriptor is `X[xs1][31:0]`; any\nupper X-register bits are ignored.",
+      "operation": "Ad[ad] = X[xs1][31:0]; raw_bits(Acc[ad]) = 0",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ad\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x1,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ad\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x1,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa210002b",
-      "operation": "Ad[ad] = X[xs1][31:0]; raw_bits(Acc[ad]) = 0"
+      "match": "0xa210002b"
     },
     {
       "order": 5,
@@ -70,12 +70,12 @@
       "synopsis": "Elementwise absolute value",
       "mnemonic": "mabs.ew md, ms1",
       "description": "Elementwise absolute value of the tensor in `ms1`, stored into `md`.",
+      "operation": "D[i] = |A[i]|",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x4,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x4,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa240002b",
-      "operation": "D[i] = |A[i]|"
+      "match": "0xa240002b"
     },
     {
       "order": 6,
@@ -85,12 +85,12 @@
       "synopsis": "Elementwise absolute difference",
       "mnemonic": "mabsdiff.ew md, ms1, ms2",
       "description": "Elementwise absolute difference of the tensors in `ms1` and `ms2`, stored into `md`.\nUsed for L1 distance and error metrics.",
+      "operation": "D[i] = |A[i] - B[i]|",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x0,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x0,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x0000002b",
-      "operation": "D[i] = |A[i] - B[i]|"
+      "match": "0x0000002b"
     },
     {
       "order": 7,
@@ -100,12 +100,12 @@
       "synopsis": "Elementwise scalar absolute difference",
       "mnemonic": "mabsdiff.ew.x md, xs1, ms2",
       "description": "Computes the elementwise absolute difference between a scalar constant from integer\nregister `xs1` and every element of square `ms2`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = |xs1 - ms2[i]|\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = |c - B[i]|",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x0200002b",
-      "operation": "D[i] = |c - B[i]|"
+      "match": "0x0200002b"
     },
     {
       "order": 8,
@@ -115,12 +115,12 @@
       "synopsis": "Elementwise addition",
       "mnemonic": "madd.ew md, ms1, ms2",
       "description": "Vector addition of the tensors in `ms1` and `ms2`, stored into `md`.",
+      "operation": "D[i] = A[i] + B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x0400002b",
-      "operation": "D[i] = A[i] + B[i]"
+      "match": "0x0400002b"
     },
     {
       "order": 9,
@@ -130,12 +130,12 @@
       "synopsis": "Elementwise scalar addition",
       "mnemonic": "madd.ew.x md, xs1, ms2",
       "description": "Adds a scalar constant from integer register `xs1` to every element of square `ms2`,\nstored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = xs1 + ms2[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = c + B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x3,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x3,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x0600002b",
-      "operation": "D[i] = c + B[i]"
+      "match": "0x0600002b"
     },
     {
       "order": 10,
@@ -145,12 +145,12 @@
       "synopsis": "Elementwise bitwise AND",
       "mnemonic": "mand.ew md, ms1, ms2",
       "description": "Elementwise bitwise AND of the tensors in `ms1` and `ms2`, stored into `md`.",
+      "operation": "D[i] = A[i] & B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1a,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1a,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x3400002b",
-      "operation": "D[i] = A[i] & B[i]"
+      "match": "0x3400002b"
     },
     {
       "order": 11,
@@ -160,12 +160,12 @@
       "synopsis": "Elementwise scalar bitwise AND",
       "mnemonic": "mand.ew.x md, xs1, ms2",
       "description": "Computes the elementwise bitwise AND of a scalar constant from integer register `xs1`\nwith every element of square `ms2`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = xs1 & ms2[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = c & B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1b,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1b,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x3600002b",
-      "operation": "D[i] = c & B[i]"
+      "match": "0x3600002b"
     },
     {
       "order": 12,
@@ -175,12 +175,12 @@
       "synopsis": "Elementwise bitwise AND-NOT",
       "mnemonic": "mandnot.ew md, ms1, ms2",
       "description": "Elementwise bitwise AND of `ms1` with the bitwise complement of `ms2`, stored into `md`.\n+\nUseful for masking and bit-field manipulation: bits set in `ms2` are cleared in the result.",
+      "operation": "D[i] = A[i] & ~B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1c,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1c,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x3800002b",
-      "operation": "D[i] = A[i] & ~B[i]"
+      "match": "0x3800002b"
     },
     {
       "order": 13,
@@ -190,12 +190,12 @@
       "synopsis": "Elementwise scalar bitwise AND-NOT",
       "mnemonic": "mandnot.ew.x md, xs1, ms2",
       "description": "Computes the elementwise bitwise AND of a scalar constant from integer register `xs1`\nwith the bitwise complement of every element of square `ms2`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = xs1 & ~ms2[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = c & ~B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1d,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1d,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x3a00002b",
-      "operation": "D[i] = c & ~B[i]"
+      "match": "0x3a00002b"
     },
     {
       "order": 14,
@@ -205,12 +205,12 @@
       "synopsis": "Elementwise two-way conditional move (non-negative)",
       "mnemonic": "mcmovge.ew md, ms1, ms2",
       "description": "Elementwise two-way conditional move using the non-negative sign of `ms1` as predicate.\n+\nFor each element, `md[i] = ms2[i]` if `ms1[i] >= 0` (sign bit clear),\notherwise `md[i]` is left unchanged.\n+\n`md` is both a source and destination: when the predicate is false (sign bit set),\nthe existing element in `md` is preserved.  `ms1` serves as the predicate register:\nany non-negative value is treated as true.\n+\nComplementary to `mcmovlt.ew`.",
+      "operation": "D[i] = (A[i] >= 0) ? B[i] : D[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2a,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2a,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x5400002b",
-      "operation": "D[i] = (A[i] >= 0) ? B[i] : D[i]"
+      "match": "0x5400002b"
     },
     {
       "order": 15,
@@ -220,12 +220,12 @@
       "synopsis": "Elementwise two-way conditional move (negative)",
       "mnemonic": "mcmovlt.ew md, ms1, ms2",
       "description": "Elementwise two-way conditional move using the sign of `ms1` as predicate.\n+\nFor each element, `md[i] = ms2[i]` if `ms1[i] < 0` (sign bit set),\notherwise `md[i]` is left unchanged.\n+\n`md` is both a source and destination: when the predicate is false (sign bit clear),\nthe existing element in `md` is preserved.  `ms1` serves as the predicate register:\nany negative value is treated as true.\n+\nComplementary to `mcmovge.ew`.",
+      "operation": "D[i] = (A[i] < 0) ? B[i] : D[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2b,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2b,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x5600002b",
-      "operation": "D[i] = (A[i] < 0) ? B[i] : D[i]"
+      "match": "0x5600002b"
     },
     {
       "order": 16,
@@ -235,12 +235,12 @@
       "synopsis": "Elementwise greater-or-equal compare",
       "mnemonic": "mcmpge.ew md, ms1, ms2",
       "description": "Elementwise greater-or-equal comparison of the tensors in `ms1` and `ms2`, stored into `md`.\n+\nFor each element, `md[i]` is set to the canonical true value (-1, all bits set) if\n`ms1[i] >= ms2[i]`, otherwise `md[i]` is set to the canonical false value (0).\n+\nFloating-point comparisons follow IEEE 754 semantics.\nComplementary to `mcmplt.ew`; both forms are provided to ensure correct behavior\nin the presence of NaN, +∞, and −∞.",
+      "operation": "D[i] = (A[i] >= B[i]) ? -1 : 0",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2c,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2c,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x5800002b",
-      "operation": "D[i] = (A[i] >= B[i]) ? -1 : 0"
+      "match": "0x5800002b"
     },
     {
       "order": 17,
@@ -250,12 +250,12 @@
       "synopsis": "Elementwise scalar compare greater-or-equal",
       "mnemonic": "mcmpge.ew.x md, xs1, ms2",
       "description": "Compares a scalar constant from integer register `xs1` against every element of square\n`ms2`, storing -1 (all bits set) where the scalar is greater than or equal to the element,\nand 0 otherwise, into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = (xs1 >= ms2[i]) ? -1 : 0\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = (c >= B[i]) ? -1 : 0",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2d,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2d,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x5a00002b",
-      "operation": "D[i] = (c >= B[i]) ? -1 : 0"
+      "match": "0x5a00002b"
     },
     {
       "order": 18,
@@ -265,12 +265,12 @@
       "synopsis": "Elementwise less-than compare",
       "mnemonic": "mcmplt.ew md, ms1, ms2",
       "description": "Elementwise less-than comparison of the tensors in `ms1` and `ms2`, stored into `md`.\n+\nFor each element, `md[i]` is set to the canonical true value (-1, all bits set) if\n`ms1[i] < ms2[i]`, otherwise `md[i]` is set to the canonical false value (0).\n+\nFloating-point comparisons follow IEEE 754 semantics.\nComplementary to `mcmpge.ew`; both forms are provided to ensure correct behavior\nin the presence of NaN, +∞, and −∞.",
+      "operation": "D[i] = (A[i] < B[i]) ? -1 : 0",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2e,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2e,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x5c00002b",
-      "operation": "D[i] = (A[i] < B[i]) ? -1 : 0"
+      "match": "0x5c00002b"
     },
     {
       "order": 19,
@@ -280,12 +280,12 @@
       "synopsis": "Elementwise scalar compare less-than",
       "mnemonic": "mcmplt.ew.x md, xs1, ms2",
       "description": "Compares a scalar constant from integer register `xs1` against every element of square\n`ms2`, storing -1 (all bits set) where the scalar is strictly less than the element,\nand 0 otherwise, into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = (xs1 < ms2[i]) ? -1 : 0\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = (c < B[i]) ? -1 : 0",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2f,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x2f,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x5e00002b",
-      "operation": "D[i] = (c < B[i]) ? -1 : 0"
+      "match": "0x5e00002b"
     },
     {
       "order": 20,
@@ -294,13 +294,13 @@
       "category": "Permutation",
       "synopsis": "Broadcast one column to all columns",
       "mnemonic": "mcolbcast.ew.x md, ms1, xs1",
-      "description": "Broadcasts column `c` (from integer register `xs1`) of `ms1` to every column of `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[i, c]\n+\nIf `c` is outside `[0, sqrt(AME_NELEM))`, an `Illegal Instruction` exception is raised.\n+\nThe `xs1` operand is a control scalar: its low 32 bits are interpreted as an\nunsigned integer column index.  It does not read `CSR[ame_scalar_dtype]` and does not undergo\nAME datatype conversion.",
+      "description": "Broadcasts column `c` (from integer register `xs1`) of `ms1` to every column of `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[i, c]\n+\nIf `c` is outside `[0, sqrt(AME_NELEM))`, an `Illegal Instruction` exception is raised.\n+\nThe `xs1` operand is a control scalar: its low 32 bits are interpreted as an\nunsigned integer column index.  It does not read `CSR[ame_scalar_dtype]` and does not undergo\nAME datatype conversion.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.",
+      "operation": "D[i,j] = A[i,c]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x32,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x32,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x6400002b",
-      "operation": "D[i,j] = A[i,c]"
+      "match": "0x6400002b"
     },
     {
       "order": 21,
@@ -309,13 +309,13 @@
       "category": "Permutation",
       "synopsis": "Elementwise column gather (take)",
       "mnemonic": "mcolgather.ew md, ms1, ms2",
-      "description": "Elementwise gather: for each element in each row, uses the corresponding index from `ms2`\nto select a column from the same row of `ms1`, and stores the result into `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[i, ms2[i,j]]\n+\n`ms2` provides integer column indices in the range `[0, sqrt(AME_NELEM))`.\nAn out-of-range index raises an `Illegal Instruction` exception.",
+      "description": "Elementwise column gather: for each element in each row, uses the corresponding index from `ms2`\nto select a column from the same row of `ms1`, and stores the result into `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[i, ms2[i,j]]\n+\n`ms2` provides integer column indices in the range `[0, sqrt(AME_NELEM))`.\nAn out-of-range index raises an `Illegal Instruction` exception.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.",
+      "operation": "D[i,j] = A[i, B[i,j]]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x33,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x33,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x6600002b",
-      "operation": "D[i,j] = A[i, B[i,j]]"
+      "match": "0x6600002b"
     },
     {
       "order": 22,
@@ -325,12 +325,12 @@
       "synopsis": "Write zero-based column index to every element",
       "mnemonic": "mcolid.ew md",
       "description": "Writes to each element of the M register group `md` the zero-based index of\nthe column containing that element.  With `N = sqrt(AME_NELEM)`, every\nelement of column `j` receives the value `j`, for `0 <= j < N`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = j\n+\nThe index value is represented in the destination datatype `Md[md]`.  The\ndestination datatype must be a supported *integer* datatype in which the\nlargest index `N-1` is exactly representable; otherwise `amestatus.UN` is\nset and no register is written.\n+\nTogether with `<<ame:doc:inst:mrowid_ew,mrowid.ew>>`, this instruction forms\nthe index group of the 1-dimensional elementwise instructions, typically\nused to materialize coordinate operands for gather, scatter, and predication\nsequences.",
+      "operation": "D[i,j] = j",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": 0x2,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r1-bank-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0x2,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": 0x53,\"type\":2}]}",
       "format": "R1",
       "mask": "0xfffff07f",
-      "match": "0xa601002b",
-      "operation": "D[i,j] = j"
+      "match": "0xa601002b"
     },
     {
       "order": 23,
@@ -339,43 +339,43 @@
       "category": "Permutation",
       "synopsis": "Elementwise column shift by scalar offset",
       "mnemonic": "mcolshift.ew.x md, ms1, xs1",
-      "description": "Elementwise column shift of `ms1` by offset `c`, obtained by interpreting the\nlow 32 bits of integer register `xs1` as a signed two's-complement integer,\nstored into `md`.  This fixed-type control operand does not read\n`CSR[ame_scalar_dtype]`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[i, j + c]  if 0 <= j + c < sqrt(AME_NELEM), otherwise\nmd[i,j] = zero(Md[md]).\n+\nElements shifted beyond the row boundary are filled with zero (no wrap-around).\nFor the row-shift form, see `mrowshift.ew.x`.",
+      "description": "Elementwise column shift of `ms1` by offset `c`, obtained by interpreting the\nlow 32 bits of integer register `xs1` as a signed two's-complement integer,\nstored into `md`.  This fixed-type control operand does not read\n`CSR[ame_scalar_dtype]`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[i, j + c]  if 0 <= j + c < sqrt(AME_NELEM), otherwise\nmd[i,j] = zero(Md[md]).\n+\nElements shifted beyond the row boundary are filled with zero (no wrap-around).\nFor the row-shift form, see `mrowshift.ew.x`.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.",
+      "operation": "D[i,j] = A[i, j+c]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x34,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x34,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x6800002b",
-      "operation": "D[i,j] = A[i, j+c]"
+      "match": "0x6800002b"
     },
     {
       "order": 24,
       "name": "mcolunzip.ew",
       "anchor": "ame:doc:inst:mcolunzip_ew",
       "category": "Permutation",
-      "synopsis": "Elementwise column unzip (de-interleave)",
-      "mnemonic": "mcolunzip.ew md, ms1",
-      "description": "De-interleaves each row of `ms1` into lower and upper halves in `md`.\n+\nLet `N = sqrt(AME_NELEM)`. For each row `i` and index `j` in `[0, N/2)`:\n+\nmd[i, j]       = ms1[i, 2j]\nmd[i, j + N/2] = ms1[i, 2j+1]\n+\nEven-indexed columns of each row are collected into the lower half of the output;\nodd-indexed columns into the upper half.  Inverse of `mcolzip.ew`.",
-      "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xa,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
-      "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xa,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
-      "format": "R2",
-      "mask": "0xfff0707f",
-      "match": "0xa2a0002b",
-      "operation": "D[i,j] = A[i,2j]\nD[i,N/2+j] = A[i,2j+1]"
+      "synopsis": "Column unzip (de-interleave columns from two inputs)",
+      "mnemonic": "mcolunzip.ew md, ms1, ms2",
+      "description": "De-interleaves the columns of the two-square logical source formed by the\nlogical source square at `ms1` followed by the logical source square at `ms2`\ninto the two destination operands `D0` and `D1`.\n+\nLet `N = sqrt(AME_NELEM)`. For each row `i` and index `j` in `[0, N/2)`:\n+\nD0[i, j]         = A[i, 2j]\nD0[i, N/2 + j]   = B[i, 2j]\nD1[i, j]         = A[i, 2j+1]\nD1[i, N/2 + j]   = B[i, 2j+1]\n+\nwhere `A` and `B` are the logical source squares at `ms1` and `ms2`.\nEven-indexed columns of the logical source are collected into `D0`;\nodd-indexed columns into `D1`.  Each source is its sole square.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.\n+\n`D0` is the logical square at `md`, and `D1` occupies the consecutive M\nregisters immediately following `D0`.  A datatype wider than\n`AME_UNIT_DATATYPE_SIZE` therefore spans multiple consecutive M registers per\ndestination operand.\n+\n`md` must be aligned to the combined register span of `D0` and `D1`\n(even-aligned when each destination operand occupies a single M register).\nInverse of `mcolzip.ew`.",
+      "operation": "D0[i,j] = A[i,2j]\nD0[i,N/2+j] = B[i,2j]\nD1[i,j] = A[i,2j+1]\nD1[i,N/2+j] = B[i,2j+1]",
+      "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x61,\"type\":2}]}",
+      "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x61,\"type\":2}]}",
+      "format": "R3",
+      "mask": "0xfe00707f",
+      "match": "0xc200002b"
     },
     {
       "order": 25,
       "name": "mcolzip.ew",
       "anchor": "ame:doc:inst:mcolzip_ew",
       "category": "Permutation",
-      "synopsis": "Elementwise column zip (interleave)",
-      "mnemonic": "mcolzip.ew md, ms1",
-      "description": "Interleaves the lower and upper halves of each row of `ms1` into `md`.\n+\nLet `N = sqrt(AME_NELEM)`. For each row `i` and index `j` in `[0, N/2)`:\n+\nmd[i, 2j]   = ms1[i, j]\nmd[i, 2j+1] = ms1[i, j + N/2]\n+\nThe lower half of each row occupies even columns in the output; the upper half\noccupies odd columns.  Inverse of `mcolunzip.ew`.",
-      "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xb,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
-      "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xb,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
-      "format": "R2",
-      "mask": "0xfff0707f",
-      "match": "0xa2b0002b",
-      "operation": "D[i,2j] = A[i,j]\nD[i,2j+1] = A[i,N/2+j]"
+      "synopsis": "Column zip (interleave columns from two inputs)",
+      "mnemonic": "mcolzip.ew md, ms1, ms2",
+      "description": "Interleaves columns from the logical source square at `ms1` and the logical\nsource square at `ms2` into the two destination operands `D0` and `D1`.\n+\nLet `N = sqrt(AME_NELEM)`. For each row `i` and index `j` in `[0, N/2)`:\n+\nD0[i, 2j]     = A[i, j]\nD0[i, 2j+1]   = B[i, j]\nD1[i, 2j]     = A[i, N/2 + j]\nD1[i, 2j+1]   = B[i, N/2 + j]\n+\nwhere `A` and `B` are the logical source squares at `ms1` and `ms2`.\nColumns from `A` appear at even positions and columns from `B` appear at\nodd positions within the two-square logical destination.  Each source is its\nsole square.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.\n+\n`D0` is the logical square at `md`, and `D1` occupies the consecutive M\nregisters immediately following `D0`.  A datatype wider than\n`AME_UNIT_DATATYPE_SIZE` therefore spans multiple consecutive M registers per\ndestination operand.\n+\n`md` must be aligned to the combined register span of `D0` and `D1`\n(even-aligned when each destination operand occupies a single M register).\nInverse of `mcolunzip.ew`.",
+      "operation": "D0[i,2j] = A[i,j]\nD0[i,2j+1] = B[i,j]\nD1[i,2j] = A[i,N/2+j]\nD1[i,2j+1] = B[i,N/2+j]",
+      "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x62,\"type\":2}]}",
+      "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x62,\"type\":2}]}",
+      "format": "R3",
+      "mask": "0xfe00707f",
+      "match": "0xc400002b"
     },
     {
       "order": 26,
@@ -384,13 +384,13 @@
       "category": "Register move / data conversion",
       "synopsis": "Convert element data between supported datatypes, including packed and non-packed representations",
       "mnemonic": "mconv.ew md, ms1",
-      "description": "Converts element data between a packed datatype and a non-packed datatype.\n+\nThe source datatype is determined from `Md[ms1]` and the destination datatype from `Md[md]`.\nExactly one of the two must be a packed datatype (size < `AME_UNIT_DATATYPE_SIZE`);\nif both or neither are packed, `mconv.ew` sets `amestatus.UN` and returns without\nmodifying any register.\n+\n**Expand (packed → non-packed):** When `Md[ms1]` is packed and `Md[md]` is a\nnon-packed datatype, `ms1` holds `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`\npacked squares. `mconv.ew` converts each element from the packed datatype to the non-packed\ndatatype and writes `pack_factor` consecutive result-square groups.  If the\ndestination square occupies `dst_group_size` registers, square `sq` begins at\n`md + sq * dst_group_size`.  The base must be aligned to `dst_group_size`, and\nthe complete `pack_factor * dst_group_size` span must fit in the M register\nfile; otherwise, `mconv.ew` raises an `Illegal Instruction` exception.\n+\n**Compress (non-packed → packed):** When `Md[ms1]` is a non-packed datatype and `Md[md]`\nis packed, `pack_factor` consecutive non-packed square groups begin at `ms1`.\nIf each source square occupies `src_group_size` registers, square `sq` begins\nat `ms1 + sq * src_group_size`.\n`mconv.ew` converts each element from the non-packed datatype to the packed datatype and packs\nall `pack_factor` result squares into the single register `md`.\nThe base must be aligned to `src_group_size`, and the complete\n`pack_factor * src_group_size` span must fit; otherwise, `mconv.ew` raises an\n`Illegal Instruction` exception.\n+\nElement conversion follows the common datatype conversion rules; unsupported conversion tuples set\n`amestatus.UN` and do not modify any register.",
+      "description": "Converts element data between supported datatypes.\n+\nThe source datatype is determined from `Md[ms1]` and the destination datatype from `Md[md]`.\nThe source and destination datatypes may each be a packed or a non-packed datatype; no\nparticular packedness combination is required.  Both operands are formed by the common\noperand-formation rules, so the instruction's square count is `N_sq = max(pack_factor)`\nand every operand spans exactly `N_sq` squares.\n+\n`mconv.ew` converts each element of the formed logical source operand from the source\ndatatype to the destination datatype and writes the result squares to the formed logical\ndestination operand.  A packed source with a non-packed destination therefore expands\nthe source squares; a non-packed source with a packed destination compresses them; and\noperands with the same packedness convert each element without changing the square layout.\n+\nElement conversion follows the common datatype conversion rules; unsupported conversion tuples set\n`amestatus.UN` and do not modify any register.",
+      "operation": "D = convert(A) over every element of the formed logical operands",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xd,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xd,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa2d0002b",
-      "operation": "D = convert(A) over every element of the formed logical operands"
+      "match": "0xa2d0002b"
     },
     {
       "order": 27,
@@ -400,12 +400,12 @@
       "synopsis": "Convert an X-register scalar and broadcast it to an M operand",
       "mnemonic": "mbcast.m.x md, xs1, xtyp",
       "description": "Interprets the low 32 bits of `X[xtyp]` as an AME datatype encoding and the\nX-register bit pattern as one scalar of that datatype, where\n`src_dtype = X[xtyp][31:0]`.  If `sizeof(src_dtype)` is less than XLEN, only\nthe low `sizeof(src_dtype)` bits are used and higher X-register bits are\nignored; if it is greater than XLEN, `X[xs1]` is zero-extended to that width.\nThe\nscalar is converted once to the destination datatype `Md[md]` using the\ncommon scalar conversion rules, then the converted value is written to every\nlogical element of `M[md]`.  Packed destinations receive the value in every\nlogical packed element.\n+\nThe source and destination datatype encodings must be supported, and the\nsource-to-destination conversion must be supported.  Otherwise,\n`amestatus.UN` is set and no destination state is modified.  The instruction\ndoes not read `CSR[ame_scalar_dtype]`; the source datatype is its explicit\n`xtyp` operand.",
+      "operation": "D[i] = convert(X[xs1], source datatype X[xtyp], destination datatype Md[md])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"md\",\"type\":4},{\"bits\":3,\"name\":{ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":5,\"name\":\"xtyp\",\"type\":4},{\"bits\":7,\"name\":0x58,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"md\",\"type\":4},{\"bits\":3,\"name\":0x0,\"type\":2},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":5,\"name\":\"xtyp\",\"type\":4},{\"bits\":7,\"name\":0x58,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xb000002b",
-      "operation": "D[i] = convert(X[xs1], source datatype X[xtyp], destination datatype Md[md])"
+      "match": "0xb000002b"
     },
     {
       "order": 28,
@@ -415,12 +415,12 @@
       "synopsis": "Elementwise cosine",
       "mnemonic": "mcos.ew md, ms1",
       "description": "Elementwise cosine of `ms1`, stored into `md`.\n+\nThis instruction is defined only for floating-point datatypes. If the datatype of\n`md` or `ms1` is not a supported floating-point type, `amestatus.UN` is set and no\nregister is written.\n+\nThe numerical precision of the result is implementation-defined.",
+      "operation": "D[i] = cos(A[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xe,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xe,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa2e0002b",
-      "operation": "D[i] = cos(A[i])"
+      "match": "0xa2e0002b"
     },
     {
       "order": 29,
@@ -430,12 +430,12 @@
       "synopsis": "Elementwise base-2 exponentiation",
       "mnemonic": "mexp2.ew md, ms1",
       "description": "Elementwise base-2 exponentiation of the tensor in `ms1`, stored into `md`.\n+\nFor each element, `md[i] = 2^ms1[i]`.",
+      "operation": "D[i] = pow2(A[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xf,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xf,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa2f0002b",
-      "operation": "D[i] = pow2(A[i])"
+      "match": "0xa2f0002b"
     },
     {
       "order": 30,
@@ -445,12 +445,12 @@
       "synopsis": "Round float to integral (toward -inf)",
       "mnemonic": "mfrintm.ew md, ms1",
       "description": "Rounds each floating-point element of `ms1` to an integral value toward minus infinity (floor), stored into `md`.\n+\nThis instruction is defined only for floating-point datatypes. If the datatype of\n`md` or `ms1` is not a supported floating-point type, `amestatus.UN` is set and no\nregister is written.",
+      "operation": "D[i] = floor(A[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x5,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x5,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa250002b",
-      "operation": "D[i] = floor(A[i])"
+      "match": "0xa250002b"
     },
     {
       "order": 31,
@@ -460,12 +460,12 @@
       "synopsis": "Round float to integral (nearest, ties to even)",
       "mnemonic": "mfrintn.ew md, ms1",
       "description": "Rounds each floating-point element of `ms1` to the nearest integral value, with ties rounded to even, stored into `md`.\n+\nThis instruction is defined only for floating-point datatypes. If the datatype of\n`md` or `ms1` is not a supported floating-point type, `amestatus.UN` is set and no\nregister is written.",
+      "operation": "D[i] = roundTiesToEven(A[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x6,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x6,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa260002b",
-      "operation": "D[i] = roundTiesToEven(A[i])"
+      "match": "0xa260002b"
     },
     {
       "order": 32,
@@ -475,12 +475,12 @@
       "synopsis": "Round float to integral (toward +inf)",
       "mnemonic": "mfrintp.ew md, ms1",
       "description": "Rounds each floating-point element of `ms1` to an integral value toward positive infinity (ceil), stored into `md`.\n+\nThis instruction is defined only for floating-point datatypes. If the datatype of\n`md` or `ms1` is not a supported floating-point type, `amestatus.UN` is set and no\nregister is written.",
+      "operation": "D[i] = ceil(A[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x7,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x7,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa270002b",
-      "operation": "D[i] = ceil(A[i])"
+      "match": "0xa270002b"
     },
     {
       "order": 33,
@@ -490,12 +490,12 @@
       "synopsis": "Round float to integral (toward zero)",
       "mnemonic": "mfrintz.ew md, ms1",
       "description": "Rounds each floating-point element of `ms1` to an integral value toward zero (truncate), stored into `md`.\n+\nThis instruction is defined only for floating-point datatypes. If the datatype of\n`md` or `ms1` is not a supported floating-point type, `amestatus.UN` is set and no\nregister is written.",
+      "operation": "D[i] = trunc(A[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x8,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x8,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa280002b",
-      "operation": "D[i] = trunc(A[i])"
+      "match": "0xa280002b"
     },
     {
       "order": 34,
@@ -505,12 +505,12 @@
       "synopsis": "Get datatype",
       "mnemonic": "mgettyp xd, ms1",
       "description": "Gets the 32-bit datatype descriptor of an `M` register by reading from `Md`\nand zero-extending it to XLEN in `X[xd]`.",
+      "operation": "X[xd] = zero_extend_XLEN(Md[ms1])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"xd\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x2,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"xd\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x2,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa220002b",
-      "operation": "X[xd] = zero_extend_XLEN(Md[ms1])"
+      "match": "0xa220002b"
     },
     {
       "order": 35,
@@ -520,12 +520,12 @@
       "synopsis": "Elementwise half-difference",
       "mnemonic": "mhdiff.ew md, ms1, ms2",
       "description": "Elementwise half-difference of the tensors in `ms1` and `ms2`, stored into `md`.\nComputes the true half-difference; pairs with `mmean.ew`.",
+      "operation": "D[i] = (B[i] - A[i]) / 2",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x0800002b",
-      "operation": "D[i] = (B[i] - A[i]) / 2"
+      "match": "0x0800002b"
     },
     {
       "order": 36,
@@ -535,12 +535,12 @@
       "synopsis": "Elementwise scalar half-difference",
       "mnemonic": "mhdiff.ew.x md, xs1, ms2",
       "description": "Computes the elementwise half-difference between a scalar constant from integer register\n`xs1` and every element of square `ms2`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = (xs1 - ms2[i]) / 2\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = (c - B[i]) / 2",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x5,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x5,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x0a00002b",
-      "operation": "D[i] = (c - B[i]) / 2"
+      "match": "0x0a00002b"
     },
     {
       "order": 37,
@@ -550,12 +550,12 @@
       "synopsis": "Elementwise left-shift scale (ldexp)",
       "mnemonic": "mldexp.ew md, ms1, ms2",
       "description": "Elementwise scale of `ms1` by a power of two given by `ms2`, stored into `md`.\n+\nFor each element, `md[i] = ms1[i] * 2^ms2[i]`.\n+\nEquivalent to C `ldexp` applied elementwise.\nComplementary to `mrdexp.ew`.",
+      "operation": "D[i] = A[i] × pow2(B[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x3f,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x3f,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x7e00002b",
-      "operation": "D[i] = A[i] × pow2(B[i])"
+      "match": "0x7e00002b"
     },
     {
       "order": 38,
@@ -565,12 +565,12 @@
       "synopsis": "Elementwise scalar left-shift scale (ldexp)",
       "mnemonic": "mldexp.ew.x md, xs1, ms2",
       "description": "Scales every element of square `ms2` by a power of two given by a scalar integer\nfrom integer register `xs1`, stored into `md`.\n+\nFor each element position `i`:\n+\nmd[i] = ms2[i] * 2^xs1\n+\nThe type of the matrix elements is determined by `Md[ms2]`. `X[xs1]` is\nzero-extended or low-bit truncated to the width of\n<<ame:doc:param:AME_MAX_INT_DTYPE,AME_MAX_INT_DTYPE>> and then interpreted using\nthat integer datatype.  The exponent is a fixed-type control operand and does\nnot read `CSR[ame_scalar_dtype]`.\n+\nEquivalent to C `ldexp` applied elementwise with a broadcast scalar exponent.\nComplementary to `mrdexp.ew`.\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = B[i] × pow2(c)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x40,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x40,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x8000002b",
-      "operation": "D[i] = B[i] × pow2(c)"
+      "match": "0x8000002b"
     },
     {
       "order": 39,
@@ -580,12 +580,12 @@
       "synopsis": "Elementwise left-shift scale accumulate",
       "mnemonic": "mldexpacc.ew md, ms1, ms2",
       "description": "Elementwise left-shift scale of `ms1` by a power of two given by `ms2`, accumulated into `md`.\n+\nFor each element, `md[i] = md[i] + ms1[i] * 2^ms2[i]`.\n+\n`md` is both a source and destination: the existing element is read, the scaled value\nis added, and the sum is written back.\n+\nComplementary to `mrdexpacc.ew`.",
+      "operation": "D[i] = D[i] + A[i] × pow2(B[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x41,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x41,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x8200002b",
-      "operation": "D[i] = D[i] + A[i] × pow2(B[i])"
+      "match": "0x8200002b"
     },
     {
       "order": 40,
@@ -595,12 +595,12 @@
       "synopsis": "Elementwise scalar left-shift scale accumulate",
       "mnemonic": "mldexpacc.ew.x md, xs1, ms2",
       "description": "Scales every element of square `ms2` by a power of two given by a scalar integer\nfrom integer register `xs1`, accumulated into `md`.\n+\nFor each element position `i`:\n+\nmd[i] = md[i] + ms2[i] * 2^xs1\n+\n`md` is both a source and destination: the existing element is read, the scaled value\nis added, and the sum is written back.\n+\nThe type of the matrix elements is determined by `Md[ms2]`. `X[xs1]` is\nzero-extended or low-bit truncated to the width of\n<<ame:doc:param:AME_MAX_INT_DTYPE,AME_MAX_INT_DTYPE>> and then interpreted using\nthat integer datatype.  The exponent is a fixed-type control operand and does\nnot read `CSR[ame_scalar_dtype]`.\n+\nComplementary to `mrdexpacc.ew`.\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = D[i] + B[i] × pow2(c)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x42,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x42,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x8400002b",
-      "operation": "D[i] = D[i] + B[i] × pow2(c)"
+      "match": "0x8400002b"
     },
     {
       "order": 41,
@@ -610,12 +610,12 @@
       "synopsis": "Elementwise base-2 logarithm",
       "mnemonic": "mlog2.ew md, ms1",
       "description": "Elementwise base-2 logarithm of the tensor in `ms1`, stored into `md`.\n+\nFor each element, `md[i] = log2(ms1[i])`.",
+      "operation": "D[i] = log2(A[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x10,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x10,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa300002b",
-      "operation": "D[i] = log2(A[i])"
+      "match": "0xa300002b"
     },
     {
       "order": 42,
@@ -625,12 +625,12 @@
       "synopsis": "Elementwise log2 minus bias",
       "mnemonic": "mlog2sub.ew md, ms1, ms2",
       "description": "Elementwise biased base-2 logarithm: subtracts `ms2` from the base-2 logarithm\nof the absolute value of `ms1`, stored into `md`.\n+\nFor each element, `md[i] = log2(|ms1[i]|) - ms2[i]`.\n+\nUseful for biased-exponent arithmetic, where `ms2` holds the bias value.\nComplementary to `msublog2.ew`.",
+      "operation": "D[i] = log2(abs(A[i])) - B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x43,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x43,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x8600002b",
-      "operation": "D[i] = log2(abs(A[i])) - B[i]"
+      "match": "0x8600002b"
     },
     {
       "order": 43,
@@ -640,12 +640,12 @@
       "synopsis": "Elementwise log2 minus scalar bias",
       "mnemonic": "mlog2sub.ew.x md, xs1, ms2",
       "description": "Computes the elementwise base-2 logarithm of the absolute value of every element of\nsquare `ms2`, minus a scalar bias from integer register `xs1`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before being used as the bias for every element position `i`:\n+\nmd[i] = log2(|ms2[i]|) - xs1\n+\nUseful for biased-exponent arithmetic, where `xs1` holds the bias value.\nComplementary to `msublog2.ew.x`.\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = log2(abs(B[i])) - c",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x44,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x44,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x8800002b",
-      "operation": "D[i] = log2(abs(B[i])) - c"
+      "match": "0x8800002b"
     },
     {
       "order": 44,
@@ -655,12 +655,12 @@
       "synopsis": "Load raw M register from implementation-defined format",
       "mnemonic": "mls md, xs1",
       "description": "Loads exactly one physical M register from memory in the implementation-defined\nregister format into matrix register `md`.\n+\nThe data in memory must have been previously stored in the implementation-defined\nregister format (e.g., by a matching `mss` instruction). No datatype conversion is\nperformed; the in-memory layout is the exact physical-register representation.\nThe datatype in `Md[md]` is not interpreted.  Consequently, packed sub-squares\nresident in `md` are transferred together, while a wide logical square requires\none `mls` for each physical M register in its group.\n+\nFor portable interoperability with other implementations, use\n<<ame:doc:inst:mls_rm,mls.rm>> or <<ame:doc:inst:mls_cm,mls.cm>>.\n+\nThe transfer size is `AME_MATRIX_REGISTER_SIZE / 8` bytes.  The address must\nbe aligned to that size or 4KB, whichever is smaller. Otherwise, `mls` raises\na `Load Misaligned` exception.",
+      "operation": "md <= mem[xs1]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x16,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x16,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa360002b",
-      "operation": "md <= mem[xs1]"
+      "match": "0xa360002b"
     },
     {
       "order": 45,
@@ -670,12 +670,12 @@
       "synopsis": "Load square from column-major format",
       "mnemonic": "mls.cm md, xs1",
       "description": "Loads a square from memory in column-major format into matrix register `md`.\n+\nThe datatype is determined from `Md[md]`. For compute datatypes\n(size >= `AME_UNIT_DATATYPE_SIZE`), one square is loaded. For packed datatypes\n(size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[md])`\nsquares are loaded and packed into a single M register.\n+\nThe data in memory is stored contiguously in column-major order: within each sub-square,\ncolumn `j` immediately follows column `j-1` with no padding. All elements are loaded\nunconditionally.\n+\nLet `total_bytes = ceil(pack_factor * AME_NELEM * sizeof(Md[md]) / 8)`.\nThe address must be aligned to `total_bytes` or 4KB, whichever is smaller.\nOtherwise, `mls.cm` raises a `Load Misaligned` exception.",
+      "operation": "md <= mem[xs1]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x17,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x17,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa370002b",
-      "operation": "md <= mem[xs1]"
+      "match": "0xa370002b"
     },
     {
       "order": 46,
@@ -685,12 +685,12 @@
       "synopsis": "Load square from row-major format",
       "mnemonic": "mls.rm md, xs1",
       "description": "Loads a square from memory in row-major format into matrix register `md`.\n+\nThe datatype is determined from `Md[md]`. For compute datatypes\n(size >= `AME_UNIT_DATATYPE_SIZE`), one square is loaded. For packed datatypes\n(size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[md])`\nsquares are loaded and packed into a single M register.\n+\nThe data in memory is stored contiguously in row-major order: within each sub-square,\nrow `i` immediately follows row `i-1` with no padding. All elements are loaded\nunconditionally.\n+\nLet `total_bytes = ceil(pack_factor * AME_NELEM * sizeof(Md[md]) / 8)`.\nThe address must be aligned to `total_bytes` or 4KB, whichever is smaller.\nOtherwise, `mls.rm` raises a `Load Misaligned` exception.",
+      "operation": "md <= mem[xs1]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x18,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x18,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa380002b",
-      "operation": "md <= mem[xs1]"
+      "match": "0xa380002b"
     },
     {
       "order": 47,
@@ -700,12 +700,12 @@
       "synopsis": "Load square from strided memory format",
       "mnemonic": "mls.st md, (xs1), xs2",
       "description": "Loads a square from memory in strided format into matrix register `md`.\n+\nThe datatype is determined from `Md[md]`. For compute datatypes\n(size >= `AME_UNIT_DATATYPE_SIZE`), one square is loaded. For packed datatypes\n(size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[md])`\nsquares are loaded and packed into a single M register.\n+\nThe strided load accesses memory as a sequence of equally spaced segments.\nFor non-packed datatypes, there are `sqrt(AME_NELEM)` segments, one per row, each\ncontaining `sqrt(AME_NELEM)` contiguous elements.\nFor packed datatypes, there are still `sqrt(AME_NELEM)` segments, but each segment\ncontains `pack_factor * sqrt(AME_NELEM)` contiguous elements — `pack_factor` sub-squares\nplaced side by side horizontally within each row.\nConsecutive segments are separated by a byte stride supplied in integer register `xs2`.\n+\nLet `element_bytes = ceil(sizeof(Md[md]) / 8)`.  The address must be aligned\nto `element_bytes` or 4KB, whichever is smaller. Otherwise, `mls.st` raises a\n`Load Misaligned` exception.  Segment byte counts and sub-byte packing follow\nthe common memory rules.",
+      "operation": "md <= mem[xs1, stride=xs2]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"xs2\",\"type\":4},{\"bits\":7,\"name\": 0x54,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"xs2\",\"type\":4},{\"bits\":7,\"name\": 0x54,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xa800002b",
-      "operation": "md <= mem[xs1, stride=xs2]"
+      "match": "0xa800002b"
     },
     {
       "order": 48,
@@ -715,12 +715,12 @@
       "synopsis": "Load square from transposed strided memory format",
       "mnemonic": "mls.tst md, (xs1), xs2",
       "description": "Loads a square from memory in transposed strided format into matrix register `md`.\n+\nThe datatype is determined from `Md[md]`. For compute datatypes\n(size >= `AME_UNIT_DATATYPE_SIZE`), one square is loaded. For packed datatypes\n(size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[md])`\nsquares are loaded and packed into a single M register.\n+\nThe transposed strided load accesses memory as a sequence of equally spaced segments,\none segment per column of the square. Each segment contains `sqrt(AME_NELEM)` contiguous\nelements, and consecutive segments are separated by a byte stride supplied in integer\nregister `xs2`. For packed datatypes, the total number of segments is\n`pack_factor * sqrt(AME_NELEM)` — one column per sub-square, stacked vertically.\nThe segment addresses and within-segment bit offsets are defined by the common\nmemory rules; this arrangement transposes each square during the transfer.\n+\nLet `element_bytes = ceil(sizeof(Md[md]) / 8)`.  The address must be aligned\nto `element_bytes` or 4KB, whichever is smaller. Otherwise, `mls.tst` raises a\n`Load Misaligned` exception.",
+      "operation": "md <= mem[xs1, stride=xs2]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"xs2\",\"type\":4},{\"bits\":7,\"name\": 0x55,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"xs2\",\"type\":4},{\"bits\":7,\"name\": 0x55,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xaa00002b",
-      "operation": "md <= mem[xs1, stride=xs2]"
+      "match": "0xaa00002b"
     },
     {
       "order": 49,
@@ -730,12 +730,12 @@
       "synopsis": "Elementwise maximum",
       "mnemonic": "mmax.ew md, ms1, ms2",
       "description": "Elementwise maximum of the tensors in `ms1` and `ms2`, stored into `md`.\nUsed for ReLU, pooling, and clipping.",
+      "operation": "D[i] = max(A[i], B[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x6,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x6,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x0c00002b",
-      "operation": "D[i] = max(A[i], B[i])"
+      "match": "0x0c00002b"
     },
     {
       "order": 50,
@@ -745,12 +745,12 @@
       "synopsis": "Elementwise scalar maximum",
       "mnemonic": "mmax.ew.x md, xs1, ms2",
       "description": "Computes the elementwise maximum of a scalar constant from integer register `xs1` and\nevery element of square `ms2`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = max(xs1, ms2[i])\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = max(c, B[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x7,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x7,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x0e00002b",
-      "operation": "D[i] = max(c, B[i])"
+      "match": "0x0e00002b"
     },
     {
       "order": 51,
@@ -760,12 +760,12 @@
       "synopsis": "Elementwise arithmetic mean (half-add)",
       "mnemonic": "mmean.ew md, ms1, ms2",
       "description": "Elementwise arithmetic mean of the tensors in `ms1` and `ms2`, stored into `md`.\nReduces overflow risk compared to a full add followed by a right shift.",
+      "operation": "D[i] = (A[i] + B[i]) / 2",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x8,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x8,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x1000002b",
-      "operation": "D[i] = (A[i] + B[i]) / 2"
+      "match": "0x1000002b"
     },
     {
       "order": 52,
@@ -775,12 +775,12 @@
       "synopsis": "Elementwise scalar mean",
       "mnemonic": "mmean.ew.x md, xs1, ms2",
       "description": "Computes the elementwise mean of a scalar constant from integer register `xs1` and\nevery element of square `ms2`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = (xs1 + ms2[i]) / 2\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = (c + B[i]) / 2",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x9,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x9,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x1200002b",
-      "operation": "D[i] = (c + B[i]) / 2"
+      "match": "0x1200002b"
     },
     {
       "order": 53,
@@ -790,12 +790,12 @@
       "synopsis": "Elementwise minimum",
       "mnemonic": "mmin.ew md, ms1, ms2",
       "description": "Elementwise minimum of the tensors in `ms1` and `ms2`, stored into `md`.\nUsed for clipping and piecewise functions.",
+      "operation": "D[i] = min(A[i], B[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xa,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xa,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x1400002b",
-      "operation": "D[i] = min(A[i], B[i])"
+      "match": "0x1400002b"
     },
     {
       "order": 54,
@@ -805,12 +805,12 @@
       "synopsis": "Elementwise scalar minimum",
       "mnemonic": "mmin.ew.x md, xs1, ms2",
       "description": "Computes the elementwise minimum of a scalar constant from integer register `xs1` and\nevery element of square `ms2`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = min(xs1, ms2[i])\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = min(c, B[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xb,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xb,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x1600002b",
-      "operation": "D[i] = min(c, B[i])"
+      "match": "0x1600002b"
     },
     {
       "order": 55,
@@ -820,12 +820,12 @@
       "synopsis": "Elementwise unconditional move from accumulator to M register",
       "mnemonic": "mmov.m.a md, acc",
       "description": "Copies the source square from the accumulator operand to the M register `md`.\n+\nThe element datatype of `acc` (from `Ad[acc]`) and `md` (from `Md[md]`)\nmust match; if they differ, `amestatus.UN` is set and `md` is left unchanged.\n+\nLet `N = sqrt(AME_NELEM)`.  For non-packed datatypes\n(`pack_factor = 1`), the single accumulator `acc` holds one `N x N` square.\nAll `AME_NELEM` elements are copied to the M register group `md`; a wide\ndatatype occupies a group of consecutive M registers.\n+\nFor packed datatypes\n(`pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[md]) > 1`), the\n`pack_factor` consecutive accumulators starting at `acc` each hold one\n`N x N` square, and all `pack_factor` squares are packed into the single M\nregister `md`.  If `pack_factor` exceeds\n<<ame:doc:param:AME_NUM_ACC_REGS,AME_NUM_ACC_REGS>>, `amestatus.UN` is set and\n`md` is left unchanged.  Otherwise, every derived accumulator index in\n`acc .. acc + pack_factor - 1` is checked according to\n<<ame:doc:param:AME_UNIMPL_ACC_BEHAVIOR,AME_UNIMPL_ACC_BEHAVIOR>> before any\naccumulator data is read or `md` is written; a failing check cannot cause a\npartial transfer.\n+\nThe destination `md` must satisfy the alignment constraint for its datatype:\n`md` must be a multiple of the number of M registers consumed by one element.\n+\nThe operand datatypes are taken only from the base registers `Ad[acc]` and\n`Md[md]`.  As with any register group, the `Md` and `Ad` values of the\nremaining registers in either group are ignored, and this instruction does\nnot modify any `Md` or `Ad` register.",
+      "operation": "D[i] = acc[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":5,\"name\": 0x1c,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":5,\"name\": 0x1c,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa3c0002b",
-      "operation": "D[i] = acc[i]"
+      "match": "0xa3c0002b"
     },
     {
       "order": 56,
@@ -835,12 +835,12 @@
       "synopsis": "Elementwise unconditional move from M register to accumulator",
       "mnemonic": "mmov.a.m acc, ms",
       "description": "Copies the source square from the M register operand `ms` to the accumulator\n`acc`.\n+\nThe element datatype of `ms` (from `Md[ms]`) and `acc` (from `Ad[acc]`)\nmust match; if they differ, `amestatus.UN` is set and `acc` is left unchanged.\n+\nLet `N = sqrt(AME_NELEM)`.  For non-packed datatypes\n(`pack_factor = 1`), `ms` holds one `N x N` square; a wide datatype occupies\na group of consecutive M registers.  All `AME_NELEM` elements are copied to\nthe single accumulator `acc`.\n+\nFor packed datatypes\n(`pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms]) > 1`), the single\nregister `ms` holds `pack_factor` `N x N` squares.  Each square is copied to\na consecutive accumulator starting at `acc`, so the instruction writes the\n`pack_factor` accumulators `acc`, `acc+1`, ..., `acc + pack_factor - 1`.  If\n`pack_factor` exceeds <<ame:doc:param:AME_NUM_ACC_REGS,AME_NUM_ACC_REGS>>,\n`amestatus.UN` is set and no accumulator is written.  Otherwise, every\nderived index in that complete accumulator span is checked according to\n<<ame:doc:param:AME_UNIMPL_ACC_BEHAVIOR,AME_UNIMPL_ACC_BEHAVIOR>> before any\nsource data is read or accumulator is written; a failing check cannot cause a\npartial transfer.\n+\nThe operand datatypes are taken only from the base registers `Md[ms]` and\n`Ad[acc]`.  As with any register group, the `Md` and `Ad` values of the\nremaining registers in either group are ignored, and this instruction does\nnot modify any `Md` or `Ad` register.",
+      "operation": "acc[i] = A[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms\",\"type\":4},{\"bits\":5,\"name\": 0x1d,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms\",\"type\":4},{\"bits\":5,\"name\": 0x1d,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa3d0002b",
-      "operation": "acc[i] = A[i]"
+      "match": "0xa3d0002b"
     },
     {
       "order": 57,
@@ -850,12 +850,12 @@
       "synopsis": "Elementwise unconditional move between M registers",
       "mnemonic": "mmov.m.m md, ms",
       "description": "Copies all elements from `ms` to `md`.\n+\nThe element datatype of `ms` and `md` must match; if they differ,\n`amestatus.UN` is set and `md` is left unchanged.\n+\n`ms` and `md` must satisfy the same alignment constraints as any other\ninstruction using that datatype.",
+      "operation": "D[i] = A[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms\",\"type\":4},{\"bits\":5,\"name\": 0x1e,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms\",\"type\":4},{\"bits\":5,\"name\": 0x1e,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa3e0002b",
-      "operation": "D[i] = A[i]"
+      "match": "0xa3e0002b"
     },
     {
       "order": 58,
@@ -865,12 +865,12 @@
       "synopsis": "Move one 8-bit scalar into an M register position (debug)",
       "mnemonic": "mmove8.m.x md, xs2, xs1",
       "description": "Writes the low 8 bits of `X[xs2]` into one 8-bit element position of the\nsingle M register `md`.  The contents of `md` are viewed, in row-major order, as\n`N = sqrt(AME_NELEM)` rows of `row_elements = (N * AME_UNIT_DATATYPE_SIZE) / 8`\n8-bit elements each, independent of the configured datatype `Md[md]`.\n+\nThe element position `pos` is selected by the low `log2(N * row_elements)`\nbits of `X[xs1]`; higher bits are ignored.  The selected column is\n`pos % row_elements` and the selected row is `pos / row_elements`.\n+\nThis instruction is intended for debugging.  The element size is defined by\nthe instruction itself: it does not read `CSR[ame_scalar_dtype]`, does not\nread or convert using `Md[md]`, does not form a register group, and never\nsets `amestatus.UN`.  The register contents are first normalized with the\nrow-major layout transformation, using the unsigned integer datatype of\nsize `AME_UNIT_DATATYPE_SIZE`, for which exactly one square occupies one M\nregister; the normalized image is then reinterpreted, by bit slicing, as\n`N` rows of `row_elements` elements of the instruction's element size.\nBoth steps are defined independently of the implementation register\nlayout, so the position-to-element mapping is identical on every\nimplementation.  If one row of the row-major\nview is narrower than the element size, an `Illegal Instruction` exception\nis raised.",
+      "operation": "D.rm[pos, 8] = X[xs2][7:0]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"md\",\"type\":4},{\"bits\":3,\"name\":{ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\":\"xs2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x59,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"md\",\"type\":4},{\"bits\":3,\"name\":0x0,\"type\":2},{\"bits\":5,\"name\":\"xs2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x59,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xb200002b",
-      "operation": "D.rm[pos, 8] = X[xs2][7:0]"
+      "match": "0xb200002b"
     },
     {
       "order": 59,
@@ -880,12 +880,12 @@
       "synopsis": "Move one 16-bit scalar into an M register position (debug)",
       "mnemonic": "mmove16.m.x md, xs2, xs1",
       "description": "Writes the low 16 bits of `X[xs2]` into one 16-bit element position of the\nsingle M register `md`.  The contents of `md` are viewed, in row-major order, as\n`N = sqrt(AME_NELEM)` rows of `row_elements = (N * AME_UNIT_DATATYPE_SIZE) / 16`\n16-bit elements each, independent of the configured datatype `Md[md]`.\n+\nThe element position `pos` is selected by the low `log2(N * row_elements)`\nbits of `X[xs1]`; higher bits are ignored.  The selected column is\n`pos % row_elements` and the selected row is `pos / row_elements`.\n+\nThis instruction is intended for debugging.  The element size is defined by\nthe instruction itself: it does not read `CSR[ame_scalar_dtype]`, does not\nread or convert using `Md[md]`, does not form a register group, and never\nsets `amestatus.UN`.  The register contents are first normalized with the\nrow-major layout transformation, using the unsigned integer datatype of\nsize `AME_UNIT_DATATYPE_SIZE`, for which exactly one square occupies one M\nregister; the normalized image is then reinterpreted, by bit slicing, as\n`N` rows of `row_elements` elements of the instruction's element size.\nBoth steps are defined independently of the implementation register\nlayout, so the position-to-element mapping is identical on every\nimplementation.  If one row of the row-major\nview is narrower than the element size, an `Illegal Instruction` exception\nis raised.",
+      "operation": "D.rm[pos, 16] = X[xs2][15:0]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"md\",\"type\":4},{\"bits\":3,\"name\":{ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\":\"xs2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5a,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"md\",\"type\":4},{\"bits\":3,\"name\":0x0,\"type\":2},{\"bits\":5,\"name\":\"xs2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5a,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xb400002b",
-      "operation": "D.rm[pos, 16] = X[xs2][15:0]"
+      "match": "0xb400002b"
     },
     {
       "order": 60,
@@ -895,12 +895,12 @@
       "synopsis": "Move one 32-bit scalar into an M register position (debug)",
       "mnemonic": "mmove32.m.x md, xs2, xs1",
       "description": "Writes the low 32 bits of `X[xs2]` into one 32-bit element position of the\nsingle M register `md`.  The contents of `md` are viewed, in row-major order, as\n`N = sqrt(AME_NELEM)` rows of `row_elements = (N * AME_UNIT_DATATYPE_SIZE) / 32`\n32-bit elements each, independent of the configured datatype `Md[md]`.\n+\nThe element position `pos` is selected by the low `log2(N * row_elements)`\nbits of `X[xs1]`; higher bits are ignored.  The selected column is\n`pos % row_elements` and the selected row is `pos / row_elements`.\n+\nThis instruction is intended for debugging.  The element size is defined by\nthe instruction itself: it does not read `CSR[ame_scalar_dtype]`, does not\nread or convert using `Md[md]`, does not form a register group, and never\nsets `amestatus.UN`.  The register contents are first normalized with the\nrow-major layout transformation, using the unsigned integer datatype of\nsize `AME_UNIT_DATATYPE_SIZE`, for which exactly one square occupies one M\nregister; the normalized image is then reinterpreted, by bit slicing, as\n`N` rows of `row_elements` elements of the instruction's element size.\nBoth steps are defined independently of the implementation register\nlayout, so the position-to-element mapping is identical on every\nimplementation.  If one row of the row-major\nview is narrower than the element size, an `Illegal Instruction` exception\nis raised.",
+      "operation": "D.rm[pos, 32] = X[xs2][31:0]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"md\",\"type\":4},{\"bits\":3,\"name\":{ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\":\"xs2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5b,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"md\",\"type\":4},{\"bits\":3,\"name\":0x0,\"type\":2},{\"bits\":5,\"name\":\"xs2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5b,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xb600002b",
-      "operation": "D.rm[pos, 32] = X[xs2][31:0]"
+      "match": "0xb600002b"
     },
     {
       "order": 61,
@@ -910,12 +910,12 @@
       "synopsis": "Move one 64-bit scalar into an M register position (debug)",
       "mnemonic": "mmove64.m.x md, xs2, xs1",
       "description": "Writes the low 64 bits of `X[xs2]` into one 64-bit element position of the\nsingle M register `md`.  The contents of `md` are viewed, in row-major order, as\n`N = sqrt(AME_NELEM)` rows of `row_elements = (N * AME_UNIT_DATATYPE_SIZE) / 64`\n64-bit elements each, independent of the configured datatype `Md[md]`.\n+\nThis 64-bit form requires `XLEN >= 64`; when `XLEN < 64`, the instruction\nraises an `Illegal Instruction` exception.\n+\nThe element position `pos` is selected by the low `log2(N * row_elements)`\nbits of `X[xs1]`; higher bits are ignored.  The selected column is\n`pos % row_elements` and the selected row is `pos / row_elements`.\n+\nThis instruction is intended for debugging.  The element size is defined by\nthe instruction itself: it does not read `CSR[ame_scalar_dtype]`, does not\nread or convert using `Md[md]`, does not form a register group, and never\nsets `amestatus.UN`.  The register contents are first normalized with the\nrow-major layout transformation, using the unsigned integer datatype of\nsize `AME_UNIT_DATATYPE_SIZE`, for which exactly one square occupies one M\nregister; the normalized image is then reinterpreted, by bit slicing, as\n`N` rows of `row_elements` elements of the instruction's element size.\nBoth steps are defined independently of the implementation register\nlayout, so the position-to-element mapping is identical on every\nimplementation.  If one row of the row-major\nview is narrower than the element size, an `Illegal Instruction` exception\nis raised.",
+      "operation": "D.rm[pos, 64] = X[xs2][63:0]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"md\",\"type\":4},{\"bits\":3,\"name\":{ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\":\"xs2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5c,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"md\",\"type\":4},{\"bits\":3,\"name\":0x0,\"type\":2},{\"bits\":5,\"name\":\"xs2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5c,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xb800002b",
-      "operation": "D.rm[pos, 64] = X[xs2][63:0]"
+      "match": "0xb800002b"
     },
     {
       "order": 62,
@@ -925,12 +925,12 @@
       "synopsis": "Move one 8-bit element from an M register position to an X register (debug)",
       "mnemonic": "mmove8.x.m xd, ms2, xs1",
       "description": "Reads one 8-bit element from the single M register `ms2` and writes it,\nzero-extended, to `X[xd]`.  The contents of `ms2` are viewed, in row-major order, as\n`N = sqrt(AME_NELEM)` rows of `row_elements = (N * AME_UNIT_DATATYPE_SIZE) / 8`\n8-bit elements each, independent of the configured datatype `Md[ms2]`.\n+\nThe element position `pos` is selected by the low `log2(N * row_elements)`\nbits of `X[xs1]`, exactly as in `<<ame:doc:inst:mmove8_m_x,mmove8.m.x>>`;\nhigher bits are ignored.  The selected column is `pos % row_elements` and\nthe selected row is `pos / row_elements`.\n+\nThis instruction is intended for debugging.  The element size is defined by\nthe instruction itself: it does not read `CSR[ame_scalar_dtype]`, does not\nread or convert using `Md[ms2]`, does not form a register group, and never\nsets `amestatus.UN`.  The register contents are first normalized with the\nrow-major layout transformation, using the unsigned integer datatype of\nsize `AME_UNIT_DATATYPE_SIZE`, for which exactly one square occupies one M\nregister; the normalized image is then reinterpreted, by bit slicing, as\n`N` rows of `row_elements` elements of the instruction's element size.\nBoth steps are defined independently of the implementation register\nlayout, so the position-to-element mapping is identical on every\nimplementation.  If one row of the row-major\nview is narrower than the element size, an `Illegal Instruction` exception\nis raised.",
+      "operation": "X[xd] = zero_extend(A.rm[pos, 8])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"xd\",\"type\":4},{\"bits\":3,\"name\":{ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\":\"ms2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5d,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"xd\",\"type\":4},{\"bits\":3,\"name\":0x0,\"type\":2},{\"bits\":5,\"name\":\"ms2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5d,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xba00002b",
-      "operation": "X[xd] = zero_extend(A.rm[pos, 8])"
+      "match": "0xba00002b"
     },
     {
       "order": 63,
@@ -940,12 +940,12 @@
       "synopsis": "Move one 16-bit element from an M register position to an X register (debug)",
       "mnemonic": "mmove16.x.m xd, ms2, xs1",
       "description": "Reads one 16-bit element from the single M register `ms2` and writes it,\nzero-extended, to `X[xd]`.  The contents of `ms2` are viewed, in row-major order, as\n`N = sqrt(AME_NELEM)` rows of `row_elements = (N * AME_UNIT_DATATYPE_SIZE) / 16`\n16-bit elements each, independent of the configured datatype `Md[ms2]`.\n+\nThe element position `pos` is selected by the low `log2(N * row_elements)`\nbits of `X[xs1]`, exactly as in `<<ame:doc:inst:mmove16_m_x,mmove16.m.x>>`;\nhigher bits are ignored.  The selected column is `pos % row_elements` and\nthe selected row is `pos / row_elements`.\n+\nThis instruction is intended for debugging.  The element size is defined by\nthe instruction itself: it does not read `CSR[ame_scalar_dtype]`, does not\nread or convert using `Md[ms2]`, does not form a register group, and never\nsets `amestatus.UN`.  The register contents are first normalized with the\nrow-major layout transformation, using the unsigned integer datatype of\nsize `AME_UNIT_DATATYPE_SIZE`, for which exactly one square occupies one M\nregister; the normalized image is then reinterpreted, by bit slicing, as\n`N` rows of `row_elements` elements of the instruction's element size.\nBoth steps are defined independently of the implementation register\nlayout, so the position-to-element mapping is identical on every\nimplementation.  If one row of the row-major\nview is narrower than the element size, an `Illegal Instruction` exception\nis raised.",
+      "operation": "X[xd] = zero_extend(A.rm[pos, 16])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"xd\",\"type\":4},{\"bits\":3,\"name\":{ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\":\"ms2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5e,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"xd\",\"type\":4},{\"bits\":3,\"name\":0x0,\"type\":2},{\"bits\":5,\"name\":\"ms2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5e,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xbc00002b",
-      "operation": "X[xd] = zero_extend(A.rm[pos, 16])"
+      "match": "0xbc00002b"
     },
     {
       "order": 64,
@@ -955,12 +955,12 @@
       "synopsis": "Move one 32-bit element from an M register position to an X register (debug)",
       "mnemonic": "mmove32.x.m xd, ms2, xs1",
       "description": "Reads one 32-bit element from the single M register `ms2` and writes it,\nzero-extended, to `X[xd]`.  The contents of `ms2` are viewed, in row-major order, as\n`N = sqrt(AME_NELEM)` rows of `row_elements = (N * AME_UNIT_DATATYPE_SIZE) / 32`\n32-bit elements each, independent of the configured datatype `Md[ms2]`.\n+\nThe element position `pos` is selected by the low `log2(N * row_elements)`\nbits of `X[xs1]`, exactly as in `<<ame:doc:inst:mmove32_m_x,mmove32.m.x>>`;\nhigher bits are ignored.  The selected column is `pos % row_elements` and\nthe selected row is `pos / row_elements`.\n+\nThis instruction is intended for debugging.  The element size is defined by\nthe instruction itself: it does not read `CSR[ame_scalar_dtype]`, does not\nread or convert using `Md[ms2]`, does not form a register group, and never\nsets `amestatus.UN`.  The register contents are first normalized with the\nrow-major layout transformation, using the unsigned integer datatype of\nsize `AME_UNIT_DATATYPE_SIZE`, for which exactly one square occupies one M\nregister; the normalized image is then reinterpreted, by bit slicing, as\n`N` rows of `row_elements` elements of the instruction's element size.\nBoth steps are defined independently of the implementation register\nlayout, so the position-to-element mapping is identical on every\nimplementation.  If one row of the row-major\nview is narrower than the element size, an `Illegal Instruction` exception\nis raised.",
+      "operation": "X[xd] = zero_extend(A.rm[pos, 32])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"xd\",\"type\":4},{\"bits\":3,\"name\":{ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\":\"ms2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5f,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"xd\",\"type\":4},{\"bits\":3,\"name\":0x0,\"type\":2},{\"bits\":5,\"name\":\"ms2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x5f,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xbe00002b",
-      "operation": "X[xd] = zero_extend(A.rm[pos, 32])"
+      "match": "0xbe00002b"
     },
     {
       "order": 65,
@@ -970,12 +970,12 @@
       "synopsis": "Move one 64-bit element from an M register position to an X register (debug)",
       "mnemonic": "mmove64.x.m xd, ms2, xs1",
       "description": "Reads one 64-bit element from the single M register `ms2` and writes it,\nzero-extended, to `X[xd]`.  The contents of `ms2` are viewed, in row-major order, as\n`N = sqrt(AME_NELEM)` rows of `row_elements = (N * AME_UNIT_DATATYPE_SIZE) / 64`\n64-bit elements each, independent of the configured datatype `Md[ms2]`.\n+\nThis 64-bit form requires `XLEN >= 64`; when `XLEN < 64`, the instruction\nraises an `Illegal Instruction` exception.\n+\nThe element position `pos` is selected by the low `log2(N * row_elements)`\nbits of `X[xs1]`, exactly as in `<<ame:doc:inst:mmove64_m_x,mmove64.m.x>>`;\nhigher bits are ignored.  The selected column is `pos % row_elements` and\nthe selected row is `pos / row_elements`.\n+\nThis instruction is intended for debugging.  The element size is defined by\nthe instruction itself: it does not read `CSR[ame_scalar_dtype]`, does not\nread or convert using `Md[ms2]`, does not form a register group, and never\nsets `amestatus.UN`.  The register contents are first normalized with the\nrow-major layout transformation, using the unsigned integer datatype of\nsize `AME_UNIT_DATATYPE_SIZE`, for which exactly one square occupies one M\nregister; the normalized image is then reinterpreted, by bit slicing, as\n`N` rows of `row_elements` elements of the instruction's element size.\nBoth steps are defined independently of the implementation register\nlayout, so the position-to-element mapping is identical on every\nimplementation.  If one row of the row-major\nview is narrower than the element size, an `Illegal Instruction` exception\nis raised.",
+      "operation": "X[xd] = zero_extend(A.rm[pos, 64])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"xd\",\"type\":4},{\"bits\":3,\"name\":{ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\":\"ms2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x60,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\":0x2b,\"type\":2},{\"bits\":5,\"name\":\"xd\",\"type\":4},{\"bits\":3,\"name\":0x0,\"type\":2},{\"bits\":5,\"name\":\"ms2\",\"type\":4},{\"bits\":5,\"name\":\"xs1\",\"type\":4},{\"bits\":7,\"name\":0x60,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xc000002b",
-      "operation": "X[xd] = zero_extend(A.rm[pos, 64])"
+      "match": "0xc000002b"
     },
     {
       "order": 66,
@@ -985,12 +985,12 @@
       "synopsis": "Matrix multiply",
       "mnemonic": "mmul.2d acc, ms1, ms2",
       "description": "Computes the matrix product of `ms1` and `ms2` and stores the result into `acc`,\ndiscarding any previous value in `acc`.\n+\n`acc[i,k] = sum over j of (ms1[i,j] * ms2[j,k])`\n+\nFor the accumulating form, see `mmulacc.2d`.",
+      "operation": "C = A × B",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x49,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x49,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x9200002b",
-      "operation": "C = A × B"
+      "match": "0x9200002b"
     },
     {
       "order": 67,
@@ -1000,12 +1000,12 @@
       "synopsis": "Elementwise multiplication",
       "mnemonic": "mmul.ew md, ms1, ms2",
       "description": "Elementwise multiplication of the tensors in `ms1` and `ms2`, stored into `md`.",
+      "operation": "D[i] = A[i] × B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xc,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xc,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x1800002b",
-      "operation": "D[i] = A[i] × B[i]"
+      "match": "0x1800002b"
     },
     {
       "order": 68,
@@ -1015,12 +1015,12 @@
       "synopsis": "Elementwise scalar multiplication",
       "mnemonic": "mmul.ew.x md, xs1, ms2",
       "description": "Multiplies every element of square `ms2` by a scalar constant from integer register\n`xs1`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = xs1 × ms2[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = c × B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xd,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xd,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x1a00002b",
-      "operation": "D[i] = c × B[i]"
+      "match": "0x1a00002b"
     },
     {
       "order": 69,
@@ -1030,12 +1030,12 @@
       "synopsis": "Matrix multiply accumulate",
       "mnemonic": "mmulacc.2d acc, ms1, ms2",
       "description": "Accumulates the matrix product of `ms1` and `ms2` into `acc`.\n+\n`acc[i,k] += sum over j of (ms1[i,j] * ms2[j,k])`\n+\n`acc` is both a source and destination: its current value is read, the matrix\nproduct is added, and the result is written back.\n+\nFor the non-accumulating form, see `mmul.2d`.\nFor the subtracting form, see `mmulaccneg.2d`.",
+      "operation": "C = C + A × B",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4a,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4a,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x9400002b",
-      "operation": "C = C + A × B"
+      "match": "0x9400002b"
     },
     {
       "order": 70,
@@ -1045,12 +1045,12 @@
       "synopsis": "Elementwise multiply-accumulate",
       "mnemonic": "mmulacc.ew md, ms1, ms2",
       "description": "Elementwise multiply-accumulate: multiplies `ms1` by `ms2` elementwise and accumulates\ninto `md`.\n+\n`md` is both a source and destination: the existing element is read, the product\n`ms1[i] × ms2[i]` is added, and the sum is written back.\n+\nFor each element position `i`:\n+\nmd[i] = md[i] + ms1[i] × ms2[i]",
+      "operation": "D[i] = D[i] + A[i] × B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xe,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xe,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x1c00002b",
-      "operation": "D[i] = D[i] + A[i] × B[i]"
+      "match": "0x1c00002b"
     },
     {
       "order": 71,
@@ -1060,12 +1060,12 @@
       "synopsis": "Elementwise scalar multiply-accumulate",
       "mnemonic": "mmulacc.ew.x md, xs1, ms2",
       "description": "Multiplies every element of square `ms2` by a scalar constant from integer register\n`xs1` and accumulates the product into `md`.\n+\n`md` is both a source and destination: the existing element is read, the scaled value\n`xs1 × ms2[i]` is added, and the sum is written back.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = md[i] + xs1 × ms2[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = D[i] + c × B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xf,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0xf,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x1e00002b",
-      "operation": "D[i] = D[i] + c × B[i]"
+      "match": "0x1e00002b"
     },
     {
       "order": 72,
@@ -1075,12 +1075,12 @@
       "synopsis": "Negated matrix multiply accumulate",
       "mnemonic": "mmulaccneg.2d acc, ms1, ms2",
       "description": "Subtracts the matrix product of `ms1` and `ms2` from `acc`.\n+\n`acc[i,k] -= sum over j of (ms1[i,j] * ms2[j,k])`\n+\n`acc` is both a source and destination: its current value is read, the matrix\nproduct is subtracted, and the result is written back.\n+\nFor the adding accumulate form, see `mmulacc.2d`.",
+      "operation": "C = C - A × B",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4b,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4b,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x9600002b",
-      "operation": "C = C - A × B"
+      "match": "0x9600002b"
     },
     {
       "order": 73,
@@ -1090,12 +1090,12 @@
       "synopsis": "Elementwise negative multiply-accumulate",
       "mnemonic": "mmulaccneg.ew md, ms1, ms2",
       "description": "Elementwise negative multiply-accumulate: multiplies `ms1` by `ms2` elementwise,\nsubtracts the product from `md`, and stores the result back into `md`.\n+\n`md` is both a source and destination: the existing element is read, the product\n`ms1[i] × ms2[i]` is subtracted, and the result is written back.\n+\nFor each element position `i`:\n+\nmd[i] = md[i] - ms1[i] × ms2[i]",
+      "operation": "D[i] = D[i] - A[i] × B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x10,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x10,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x2000002b",
-      "operation": "D[i] = D[i] - A[i] × B[i]"
+      "match": "0x2000002b"
     },
     {
       "order": 74,
@@ -1105,12 +1105,12 @@
       "synopsis": "Elementwise scalar negative multiply-accumulate",
       "mnemonic": "mmulaccneg.ew.x md, xs1, ms2",
       "description": "Multiplies every element of square `ms2` by a scalar constant from integer register\n`xs1`, subtracts the product from `md`, and stores the result back into `md`.\n+\n`md` is both a source and destination: the existing element is read, the product\n`xs1 × ms2[i]` is subtracted, and the result is written back.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = md[i] - xs1 × ms2[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = D[i] - c × B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x11,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x11,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x2200002b",
-      "operation": "D[i] = D[i] - c × B[i]"
+      "match": "0x2200002b"
     },
     {
       "order": 75,
@@ -1120,12 +1120,12 @@
       "synopsis": "Elementwise fused multiply-add",
       "mnemonic": "mmuladd.ew md, ms1, ms2",
       "description": "Elementwise fused multiply-add where `md` serves as both the multiplicand and the\ndestination.\n+\n`md` is both a source and destination: each existing element is multiplied by the\ncorresponding element of `ms2`, `ms1` is added, and the result is written back.\n+\nFor each element position `i`:\n+\nmd[i] = ms1[i] + ms2[i] × md[i]",
+      "operation": "D[i] = A[i] + B[i] × D[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x12,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x12,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x2400002b",
-      "operation": "D[i] = A[i] + B[i] × D[i]"
+      "match": "0x2400002b"
     },
     {
       "order": 76,
@@ -1135,12 +1135,12 @@
       "synopsis": "Elementwise scalar fused multiply-add",
       "mnemonic": "mmuladd.ew.x md, xs1, ms2",
       "description": "Elementwise scalar fused multiply-add where `md` serves as both the multiplicand and the\ndestination.\n+\n`md` is both a source and destination: each existing element is multiplied by the\ncorresponding element of `ms2`, the scalar `xs1` is added, and the result is written back.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = xs1 + ms2[i] × md[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = c + B[i] × D[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x13,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x13,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x2600002b",
-      "operation": "D[i] = c + B[i] × D[i]"
+      "match": "0x2600002b"
     },
     {
       "order": 77,
@@ -1150,12 +1150,12 @@
       "synopsis": "Matrix multiply with transposed A",
       "mnemonic": "mmulat.2d acc, ms1, ms2",
       "description": "Computes the matrix product of the transpose of `ms1` with `ms2` and stores the\nresult into `acc`, discarding any previous value in `acc`.\n+\n`acc[i,k] = sum over j of (ms1[j,i] * ms2[j,k])`\n+\nFor the accumulating form, see `mmulatacc.2d`.",
+      "operation": "C = sum(transpose(A[s]) × B[s], s = 0 .. pack_factor-1)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4c,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4c,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x9800002b",
-      "operation": "C = sum(transpose(A[s]) × B[s], s = 0 .. pack_factor-1)"
+      "match": "0x9800002b"
     },
     {
       "order": 78,
@@ -1165,12 +1165,12 @@
       "synopsis": "Matrix multiply with transposed A, accumulate",
       "mnemonic": "mmulatacc.2d acc, ms1, ms2",
       "description": "Accumulates the matrix product of the transpose of `ms1` with `ms2` into `acc`.\n+\n`acc[i,k] += sum over j of (ms1[j,i] * ms2[j,k])`\n+\n`acc` is both a source and destination: its current value is read, the transposed-A\nmatrix product is added, and the result is written back.\n+\nFor the non-accumulating form, see `mmulat.2d`.",
+      "operation": "C = C + sum(transpose(A[s]) × B[s], s = 0 .. pack_factor-1)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4d,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4d,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x9a00002b",
-      "operation": "C = C + sum(transpose(A[s]) × B[s], s = 0 .. pack_factor-1)"
+      "match": "0x9a00002b"
     },
     {
       "order": 79,
@@ -1180,12 +1180,12 @@
       "synopsis": "Matrix multiply with transposed B",
       "mnemonic": "mmulbt.2d acc, ms1, ms2",
       "description": "Computes the matrix product of `ms1` with the transpose of `ms2` and stores the\nresult into `acc`, discarding any previous value in `acc`.\n+\n`acc[i,k] = sum over j of (ms1[i,j] * ms2[k,j])`\n+\nFor the accumulating form, see `mmulbtacc.2d`.",
+      "operation": "C = sum(A[s] × transpose(B[s]), s = 0 .. pack_factor-1)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4e,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4e,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x9c00002b",
-      "operation": "C = sum(A[s] × transpose(B[s]), s = 0 .. pack_factor-1)"
+      "match": "0x9c00002b"
     },
     {
       "order": 80,
@@ -1195,12 +1195,12 @@
       "synopsis": "Matrix multiply with transposed B, accumulate",
       "mnemonic": "mmulbtacc.2d acc, ms1, ms2",
       "description": "Accumulates the matrix product of `ms1` with the transpose of `ms2` into `acc`.\n+\n`acc[i,k] += sum over j of (ms1[i,j] * ms2[k,j])`\n+\n`acc` is both a source and destination: its current value is read, the transposed-B\nmatrix product is added, and the result is written back.\n+\nFor the non-accumulating form, see `mmulbt.2d`.",
+      "operation": "C = C + sum(A[s] × transpose(B[s]), s = 0 .. pack_factor-1)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4f,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x4f,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x9e00002b",
-      "operation": "C = C + sum(A[s] × transpose(B[s]), s = 0 .. pack_factor-1)"
+      "match": "0x9e00002b"
     },
     {
       "order": 81,
@@ -1210,12 +1210,12 @@
       "synopsis": "Negated matrix multiply",
       "mnemonic": "mmulneg.2d acc, ms1, ms2",
       "description": "Computes the negated matrix product of `ms1` and `ms2` and stores the result into `acc`,\ndiscarding any previous value in `acc`.\n+\n`acc[i,k] = -(sum over j of (ms1[i,j] * ms2[j,k]))`\n+\nFor the accumulating negated form, see `mmulaccneg.2d`.",
+      "operation": "C = -(A × B)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x50,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x50,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xa000002b",
-      "operation": "C = -(A × B)"
+      "match": "0xa000002b"
     },
     {
       "order": 82,
@@ -1225,12 +1225,12 @@
       "synopsis": "Elementwise negate-multiply",
       "mnemonic": "mmulneg.ew md, ms1, ms2",
       "description": "Elementwise negate-multiply of the tensors in `ms1` and `ms2`, stored into `md`.\n+\nFor each element position `i`:\n+\nmd[i] = -(ms1[i] × ms2[i])",
+      "operation": "D[i] = -(A[i] × B[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x14,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x14,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x2800002b",
-      "operation": "D[i] = -(A[i] × B[i])"
+      "match": "0x2800002b"
     },
     {
       "order": 83,
@@ -1240,12 +1240,12 @@
       "synopsis": "Elementwise scalar negate-multiply",
       "mnemonic": "mmulneg.ew.x md, xs1, ms2",
       "description": "Negates the product of a scalar constant from integer register `xs1` and every element\nof square `ms2`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = -(xs1 × ms2[i])\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = -(c × B[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x15,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x15,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x2a00002b",
-      "operation": "D[i] = -(c × B[i])"
+      "match": "0x2a00002b"
     },
     {
       "order": 84,
@@ -1255,12 +1255,12 @@
       "synopsis": "Elementwise fused multiply-subtract",
       "mnemonic": "mmulsub.ew md, ms1, ms2",
       "description": "Elementwise fused multiply-subtract where `md` serves as both the multiplicand and the\ndestination.\n+\n`md` is both a source and destination: each existing element is multiplied by the\ncorresponding element of `ms2`, `ms1` is subtracted from that product, and the result\nis written back. Note: this computes `ms1 - ms2 × md`, not `ms2 × md - ms1`.\n+\nFor each element position `i`:\n+\nmd[i] = ms1[i] - ms2[i] × md[i]",
+      "operation": "D[i] = A[i] - B[i] × D[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x16,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x16,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x2c00002b",
-      "operation": "D[i] = A[i] - B[i] × D[i]"
+      "match": "0x2c00002b"
     },
     {
       "order": 85,
@@ -1270,12 +1270,12 @@
       "synopsis": "Elementwise scalar fused multiply-subtract",
       "mnemonic": "mmulsub.ew.x md, xs1, ms2",
       "description": "Elementwise scalar fused multiply-subtract where `md` serves as both the multiplicand\nand the destination.\n+\n`md` is both a source and destination: each existing element is multiplied by the\ncorresponding element of `ms2`, that product is subtracted from the scalar `xs1`,\nand the result is written back.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = xs1 - ms2[i] × md[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = c - B[i] × D[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x17,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x17,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x2e00002b",
-      "operation": "D[i] = c - B[i] × D[i]"
+      "match": "0x2e00002b"
     },
     {
       "order": 86,
@@ -1285,12 +1285,12 @@
       "synopsis": "Elementwise bitwise OR",
       "mnemonic": "mor.ew md, ms1, ms2",
       "description": "Elementwise bitwise OR of the tensors in `ms1` and `ms2`, stored into `md`.",
+      "operation": "D[i] = A[i] | B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1e,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1e,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x3c00002b",
-      "operation": "D[i] = A[i] | B[i]"
+      "match": "0x3c00002b"
     },
     {
       "order": 87,
@@ -1300,12 +1300,12 @@
       "synopsis": "Elementwise scalar bitwise OR",
       "mnemonic": "mor.ew.x md, xs1, ms2",
       "description": "Computes the elementwise bitwise OR of a scalar constant from integer register `xs1`\nwith every element of square `ms2`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = xs1 | ms2[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = c | B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1f,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x1f,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x3e00002b",
-      "operation": "D[i] = c | B[i]"
+      "match": "0x3e00002b"
     },
     {
       "order": 88,
@@ -1315,12 +1315,12 @@
       "synopsis": "Elementwise bitwise OR-NOT",
       "mnemonic": "mornot.ew md, ms1, ms2",
       "description": "Elementwise bitwise OR of `ms1` with the bitwise complement of `ms2`, stored into `md`.\n+\nUseful for setting bits: any bit clear in `ms2` will be set in the result.",
+      "operation": "D[i] = A[i] | ~B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x20,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x20,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x4000002b",
-      "operation": "D[i] = A[i] | ~B[i]"
+      "match": "0x4000002b"
     },
     {
       "order": 89,
@@ -1330,12 +1330,12 @@
       "synopsis": "Elementwise scalar bitwise OR-NOT",
       "mnemonic": "mornot.ew.x md, xs1, ms2",
       "description": "Computes the elementwise bitwise OR of a scalar constant from integer register `xs1`\nwith the bitwise complement of every element of square `ms2`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = xs1 | ~ms2[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = c | ~B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x21,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x21,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x4200002b",
-      "operation": "D[i] = c | ~B[i]"
+      "match": "0x4200002b"
     },
     {
       "order": 90,
@@ -1345,12 +1345,12 @@
       "synopsis": "Pack one square into a slot of a packed M register",
       "mnemonic": "mpack.ew.x md, ms1, xs1",
       "description": "Inserts the single non-packed square group beginning at `ms1` into the sub-square slot selected by the\nindex in integer register `xs1` of the packed M register `md`, converting each element\nfrom the non-packed datatype (`Md[ms1]`) to the packed datatype (`Md[md]`). The other\nsub-square slots of `md` are preserved (read-modify-write).\n+\n`Md[md]` must be a packed datatype and `Md[ms1]` a non-packed datatype; otherwise\n`amestatus.UN` is set and no register is written. The index must be less than\n`pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[md])`; an out-of-range index raises an\n`Illegal Instruction` exception.\nThe index is a fixed U32 unsigned integer control operand (the low 32 bits of\n`X[xs1]`) and does not read\n`CSR[ame_scalar_dtype]`.\n+\nThis is the single-square form of the pack (compress) direction of\n<<ame:doc:inst:mconv_ew,mconv.ew>>; use it to pack one square at a time without holding\nall `pack_factor` non-packed squares in registers simultaneously.",
+      "operation": "D[k] = convert(A)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x3d,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x3d,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x7a00002b",
-      "operation": "D[k] = convert(A)"
+      "match": "0x7a00002b"
     },
     {
       "order": 91,
@@ -1360,12 +1360,12 @@
       "synopsis": "Elementwise column prefix-sum (inclusive scan)",
       "mnemonic": "mprefixadd.col md, ms1",
       "description": "Computes an inclusive prefix sum (running sum) along each column of `ms1`, stored into `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = sum over k <= i of ms1[k,j]\n+\n`md[0,j] = ms1[0,j]`, `md[1,j] = ms1[0,j] + ms1[1,j]`, and so on.\nFor the row prefix-sum form, see `mprefixadd.row`.\nFor the column max-scan form, see `mprefixmax.col`.",
+      "operation": "D[i,j] = sum(A[k,j], k = 0 .. i)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x1f,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x1f,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa3f0002b",
-      "operation": "D[i,j] = sum(A[k,j], k = 0 .. i)"
+      "match": "0xa3f0002b"
     },
     {
       "order": 92,
@@ -1375,12 +1375,12 @@
       "synopsis": "Elementwise row prefix-sum (inclusive scan)",
       "mnemonic": "mprefixadd.row md, ms1",
       "description": "Computes an inclusive prefix sum (running sum) along each row of `ms1`, stored into `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = sum over k <= j of ms1[i,k]\n+\n`md[i,0] = ms1[i,0]`, `md[i,1] = ms1[i,0] + ms1[i,1]`, and so on.\nFor the row max-scan form, see `mprefixmax.row`.\nFor the column add-scan form, see `mprefixadd.col`.",
+      "operation": "D[i,j] = sum(A[i,k], k = 0 .. j)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank1-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": 0x52,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa400002b",
-      "operation": "D[i,j] = sum(A[i,k], k = 0 .. j)"
+      "match": "0xa400002b"
     },
     {
       "order": 93,
@@ -1390,12 +1390,12 @@
       "synopsis": "Elementwise column prefix-max (running maximum scan)",
       "mnemonic": "mprefixmax.col md, ms1",
       "description": "Computes a running maximum (inclusive prefix max) along each column of `ms1`, stored into `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = max over k <= i of ms1[k,j]\n+\n`md[0,j] = ms1[0,j]`, `md[1,j] = max(ms1[0,j], ms1[1,j])`, and so on.\nFor the row prefix-max form, see `mprefixmax.row`.\nFor the column add-scan form, see `mprefixadd.col`.",
+      "operation": "D[i,j] = max(A[k,j], k = 0 .. i)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x1,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank1-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x1,\"type\":2},{\"bits\":7,\"name\": 0x52,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa410002b",
-      "operation": "D[i,j] = max(A[k,j], k = 0 .. i)"
+      "match": "0xa410002b"
     },
     {
       "order": 94,
@@ -1405,12 +1405,12 @@
       "synopsis": "Elementwise row prefix-max (running maximum scan)",
       "mnemonic": "mprefixmax.row md, ms1",
       "description": "Computes a running maximum (inclusive prefix max) along each row of `ms1`, stored into `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = max over k <= j of ms1[i,k]\n+\n`md[i,0] = ms1[i,0]`, `md[i,1] = max(ms1[i,0], ms1[i,1])`, and so on.\nFor the row add-scan form, see `mprefixadd.row`.\nFor the column max-scan form, see `mprefixmax.col`.",
+      "operation": "D[i,j] = max(A[i,k], k = 0 .. j)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x2,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank1-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x2,\"type\":2},{\"bits\":7,\"name\": 0x52,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa420002b",
-      "operation": "D[i,j] = max(A[i,k], k = 0 .. j)"
+      "match": "0xa420002b"
     },
     {
       "order": 95,
@@ -1420,12 +1420,12 @@
       "synopsis": "Elementwise right-shift scale",
       "mnemonic": "mrdexp.ew md, ms1, ms2",
       "description": "Elementwise scale of `ms1` by a negative power of two given by `ms2`, stored into `md`.\n+\nFor each element, `md[i] = ms1[i] * 2^(-ms2[i])`.\n+\nEquivalent to `np.ldexp(ms1, -ms2)`.\nComplementary to `mldexp.ew`.",
+      "operation": "D[i] = A[i] × pow2(-B[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x45,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x45,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x8a00002b",
-      "operation": "D[i] = A[i] × pow2(-B[i])"
+      "match": "0x8a00002b"
     },
     {
       "order": 96,
@@ -1435,12 +1435,12 @@
       "synopsis": "Elementwise right-shift scale accumulate",
       "mnemonic": "mrdexpacc.ew md, ms1, ms2",
       "description": "Elementwise right-shift scale of `ms1` by a negative power of two given by `ms2`,\naccumulated into `md`.\n+\nFor each element, `md[i] = md[i] + ms1[i] * 2^(-ms2[i])`.\n+\n`md` is both a source and destination: the existing element is read, the scaled value\nis added, and the sum is written back.\n+\nComplementary to `mldexpacc.ew`.",
+      "operation": "D[i] = D[i] + A[i] × pow2(-B[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x46,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x46,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x8c00002b",
-      "operation": "D[i] = D[i] + A[i] × pow2(-B[i])"
+      "match": "0x8c00002b"
     },
     {
       "order": 97,
@@ -1450,12 +1450,12 @@
       "synopsis": "Elementwise reciprocal",
       "mnemonic": "mrec.ew md, ms1",
       "description": "Elementwise reciprocal of `ms1`, stored into `md`.\n+\nThis instruction is defined only for floating-point datatypes. If the datatype of\n`md` or `ms1` is not a supported floating-point type, `amestatus.UN` is set and no\nregister is written.\n+\nThe numerical precision of the result is implementation-defined.",
+      "operation": "D[i] = 1 / A[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x11,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x11,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa310002b",
-      "operation": "D[i] = 1 / A[i]"
+      "match": "0xa310002b"
     },
     {
       "order": 98,
@@ -1465,12 +1465,12 @@
       "synopsis": "Elementwise column reduce (add)",
       "mnemonic": "mreduceadd.col md, ms1",
       "description": "Reduces each column of `ms1` by addition and broadcasts the result to all rows of the\ncorresponding column in `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = sum over k of ms1[k,j]\n+\nAll rows in each output column receive the same value (the column sum).\nFor the row-reduction form, see `mreduceadd.row`.\nFor the column max-reduction form, see `mreducemax.col`.",
+      "operation": "D[:,j] = sum(A[k,j], k = 0 .. N-1)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x3,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank1-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x3,\"type\":2},{\"bits\":7,\"name\": 0x52,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa430002b",
-      "operation": "D[:,j] = sum(A[k,j], k = 0 .. N-1)"
+      "match": "0xa430002b"
     },
     {
       "order": 99,
@@ -1480,12 +1480,12 @@
       "synopsis": "Elementwise row reduce (add)",
       "mnemonic": "mreduceadd.row md, ms1",
       "description": "Reduces each row of `ms1` by addition and broadcasts the result to all columns of the\ncorresponding row in `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = sum over k of ms1[i,k]\n+\nAll columns in each output row receive the same value (the row sum).\nFor the row max-reduction form, see `mreducemax.row`.\nFor the column add-reduction form, see `mreduceadd.col`.",
+      "operation": "D[i,:] = sum(A[i,k], k = 0 .. N-1)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x4,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank1-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x4,\"type\":2},{\"bits\":7,\"name\": 0x52,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa440002b",
-      "operation": "D[i,:] = sum(A[i,k], k = 0 .. N-1)"
+      "match": "0xa440002b"
     },
     {
       "order": 100,
@@ -1495,12 +1495,12 @@
       "synopsis": "Elementwise column reduce (max)",
       "mnemonic": "mreducemax.col md, ms1",
       "description": "Reduces each column of `ms1` by maximum and broadcasts the result to all rows of the\ncorresponding column in `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = max over k of ms1[k,j]\n+\nAll rows in each output column receive the same value (the column maximum).\nFor the row-reduction form, see `mreducemax.row`.\nFor the column add-reduction form, see `mreduceadd.col`.",
+      "operation": "D[:,j] = max(A[k,j], k = 0 .. N-1)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x5,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank1-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x5,\"type\":2},{\"bits\":7,\"name\": 0x52,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa450002b",
-      "operation": "D[:,j] = max(A[k,j], k = 0 .. N-1)"
+      "match": "0xa450002b"
     },
     {
       "order": 101,
@@ -1510,12 +1510,12 @@
       "synopsis": "Elementwise row reduce (max)",
       "mnemonic": "mreducemax.row md, ms1",
       "description": "Reduces each row of `ms1` by maximum and broadcasts the result to all columns of the\ncorresponding row in `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = max over k of ms1[i,k]\n+\nAll columns in each output row receive the same value (the row maximum).\nFor the row add-reduction form, see `mreduceadd.row`.\nFor the column max-reduction form, see `mreducemax.col`.",
+      "operation": "D[i,:] = max(A[i,k], k = 0 .. N-1)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x6,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank1-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x6,\"type\":2},{\"bits\":7,\"name\": 0x52,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa460002b",
-      "operation": "D[i,:] = max(A[i,k], k = 0 .. N-1)"
+      "match": "0xa460002b"
     },
     {
       "order": 102,
@@ -1525,12 +1525,12 @@
       "synopsis": "Elementwise column reduce (min)",
       "mnemonic": "mreducemin.col md, ms1",
       "description": "Reduces each column of `ms1` by minimum and broadcasts the result to all rows of the\ncorresponding column in `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = min over k of ms1[k,j]\n+\nAll rows in each output column receive the same value (the column minimum).\nFor the row-reduction form, see `mreducemin.row`.\nFor the column max-reduction form, see `mreducemax.col`.",
+      "operation": "D[:,j] = min(A[k,j], k = 0 .. N-1)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x7,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank1-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x7,\"type\":2},{\"bits\":7,\"name\": 0x52,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa470002b",
-      "operation": "D[:,j] = min(A[k,j], k = 0 .. N-1)"
+      "match": "0xa470002b"
     },
     {
       "order": 103,
@@ -1540,12 +1540,12 @@
       "synopsis": "Elementwise row reduce (min)",
       "mnemonic": "mreducemin.row md, ms1",
       "description": "Reduces each row of `ms1` by minimum and broadcasts the result to all columns of the\ncorresponding row in `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = min over k of ms1[i,k]\n+\nAll columns in each output row receive the same value (the row minimum).\nFor the column-reduction form, see `mreducemin.col`.\nFor the row max-reduction form, see `mreducemax.row`.",
+      "operation": "D[i,:] = min(A[i,k], k = 0 .. N-1)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x8,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank1-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x8,\"type\":2},{\"bits\":7,\"name\": 0x52,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa480002b",
-      "operation": "D[i,:] = min(A[i,k], k = 0 .. N-1)"
+      "match": "0xa480002b"
     },
     {
       "order": 104,
@@ -1554,13 +1554,13 @@
       "category": "Permutation",
       "synopsis": "Broadcast one row to all rows",
       "mnemonic": "mrowbcast.ew.x md, ms1, xs1",
-      "description": "Broadcasts row `c` (from integer register `xs1`) of `ms1` to every row of `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[c, j]\n+\nIf `c` is outside `[0, sqrt(AME_NELEM))`, an `Illegal Instruction` exception is raised.\n+\nThe `xs1` operand is a control scalar: its low 32 bits are interpreted as an\nunsigned integer row index.  It does not read `CSR[ame_scalar_dtype]` and does not undergo\nAME datatype conversion.",
+      "description": "Broadcasts row `c` (from integer register `xs1`) of `ms1` to every row of `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[c, j]\n+\nIf `c` is outside `[0, sqrt(AME_NELEM))`, an `Illegal Instruction` exception is raised.\n+\nThe `xs1` operand is a control scalar: its low 32 bits are interpreted as an\nunsigned integer row index.  It does not read `CSR[ame_scalar_dtype]` and does not undergo\nAME datatype conversion.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.",
+      "operation": "D[i,j] = A[c,j]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x35,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x35,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x6a00002b",
-      "operation": "D[i,j] = A[c,j]"
+      "match": "0x6a00002b"
     },
     {
       "order": 105,
@@ -1569,13 +1569,13 @@
       "category": "Permutation",
       "synopsis": "Elementwise row gather (take)",
       "mnemonic": "mrowgather.ew md, ms1, ms2",
-      "description": "Elementwise gather: for each element in each column, uses the corresponding index from `ms2`\nto select a row from the same column of `ms1`, and stores the result into `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[ms2[i,j], j]\n+\n`ms2` provides integer row indices in the range `[0, sqrt(AME_NELEM))`.\nAn out-of-range index raises an `Illegal Instruction` exception.",
+      "description": "Elementwise row gather: for each element in each column, uses the corresponding index from `ms2`\nto select a row from the same column of `ms1`, and stores the result into `md`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[ms2[i,j], j]\n+\n`ms2` provides integer row indices in the range `[0, sqrt(AME_NELEM))`.\nAn out-of-range index raises an `Illegal Instruction` exception.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.",
+      "operation": "D[i,j] = A[B[i,j],j]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x36,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x36,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x6c00002b",
-      "operation": "D[i,j] = A[B[i,j],j]"
+      "match": "0x6c00002b"
     },
     {
       "order": 106,
@@ -1585,12 +1585,12 @@
       "synopsis": "Write zero-based row index to every element",
       "mnemonic": "mrowid.ew md",
       "description": "Writes to each element of the M register group `md` the zero-based index of\nthe row containing that element.  With `N = sqrt(AME_NELEM)`, every\nelement of row `i` receives the value `i`, for `0 <= i < N`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = i\n+\nThe index value is represented in the destination datatype `Md[md]`.  The\ndestination datatype must be a supported *integer* datatype in which the\nlargest index `N-1` is exactly representable; otherwise `amestatus.UN` is\nset and no register is written.\n+\nTogether with `<<ame:doc:inst:mcolid_ew,mcolid.ew>>`, this instruction forms\nthe index group of the 1-dimensional elementwise instructions, typically\nused to materialize coordinate operands for gather, scatter, and predication\nsequences.",
+      "operation": "D[i,j] = i",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": 0x3,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r1-bank-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0x3,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": 0x53,\"type\":2}]}",
       "format": "R1",
       "mask": "0xfffff07f",
-      "match": "0xa601802b",
-      "operation": "D[i,j] = i"
+      "match": "0xa601802b"
     },
     {
       "order": 107,
@@ -1599,28 +1599,28 @@
       "category": "Permutation",
       "synopsis": "Elementwise row shift by scalar offset",
       "mnemonic": "mrowshift.ew.x md, ms1, xs1",
-      "description": "Elementwise shift of each column of `ms1` by row offset `c`, obtained by\ninterpreting the low 32 bits of integer register `xs1` as a signed\ntwo's-complement integer, stored into `md`.  This fixed-type control operand does not read\n`CSR[ame_scalar_dtype]`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[i+c, j]  if 0 <= i+c < sqrt(AME_NELEM), otherwise\nmd[i,j] = zero(Md[md]).",
+      "description": "Elementwise row shift of `ms1` by offset `c`, obtained by interpreting the\nlow 32 bits of integer register `xs1` as a signed two's-complement integer,\nstored into `md`.  This fixed-type control operand does not read\n`CSR[ame_scalar_dtype]`.\n+\nFor each row `i` and column `j`:\n+\nmd[i,j] = ms1[i+c, j]  if 0 <= i+c < sqrt(AME_NELEM), otherwise\nmd[i,j] = zero(Md[md]).\n+\nElements shifted beyond the column boundary are filled with zero (no wrap-around).\nFor the column-shift form, see `mcolshift.ew.x`.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.",
+      "operation": "D[i,j] = A[i+c,j]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x37,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x37,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x6e00002b",
-      "operation": "D[i,j] = A[i+c,j]"
+      "match": "0x6e00002b"
     },
     {
       "order": 108,
       "name": "mrowunzip.ew",
       "anchor": "ame:doc:inst:mrowunzip_ew",
       "category": "Permutation",
-      "synopsis": "Row unzip (de-interleave rows)",
-      "mnemonic": "mrowunzip.ew md, ms1",
-      "description": "De-interleaves the rows of the source register pair (`ms1`, `ms1+1`) into the\ndestination register pair (`md`, `md+1`).\n+\nLet `N = sqrt(AME_NELEM)`. For each row `k` in `[0, N)` and column `j`:\n+\nD0[k, j] = A[2k,   j]   (even rows of the source)\nD1[k, j] = A[2k+1, j]   (odd rows of the source)\n+\nThe even-indexed rows are collected into logical destination square `D0` in\n`md`; the odd-indexed rows are collected into `D1` in `md+1`.  The datatype\nsize must be no greater than `AME_UNIT_DATATYPE_SIZE`; a wider tuple is\nunsupported.  For a packed datatype, only slot 0 of each of `ms1`, `ms1+1`,\n`md`, and `md+1` participates, and every other destination slot is preserved.\n+\n`md` must be even-aligned.  Inverse of `mrowzip.ew`.",
-      "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xc,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
-      "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0xc,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
-      "format": "R2",
-      "mask": "0xfff0707f",
-      "match": "0xa2c0002b",
-      "operation": "D0[i,:] = A[2i,:]\nD1[i,:] = A[2i+1,:]"
+      "synopsis": "Row unzip (de-interleave rows from two inputs)",
+      "mnemonic": "mrowunzip.ew md, ms1, ms2",
+      "description": "De-interleaves the rows of the two-square logical source formed by the logical\nsource square at `ms1` followed by the logical source square at `ms2` into the\ntwo destination operands `D0` and `D1`.\n+\nLet `N = sqrt(AME_NELEM)`. For each row `k` in `[0, N/2)` and column `j`:\n+\nD0[k, j]       = A[2k, j]\nD0[k+N/2, j]   = B[2k, j]\nD1[k, j]       = A[2k+1, j]\nD1[k+N/2, j]   = B[2k+1, j]\n+\nwhere `A` and `B` are the logical source squares at `ms1` and `ms2`.\nEven-indexed rows of the logical source are collected into `D0`; odd-indexed\nrows into `D1`.  Each source is its sole square.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.\n+\n`D0` is the logical square at `md`, and `D1` occupies the consecutive M\nregisters immediately following `D0`.  A datatype wider than\n`AME_UNIT_DATATYPE_SIZE` therefore spans multiple consecutive M registers per\ndestination operand.\n+\n`md` must be aligned to the combined register span of `D0` and `D1`\n(even-aligned when each destination operand occupies a single M register).\nInverse of `mrowzip.ew`.",
+      "operation": "D0[k,j] = A[2k,j]\nD0[k+N/2,j] = B[2k,j]\nD1[k,j] = A[2k+1,j]\nD1[k+N/2,j] = B[2k+1,j]",
+      "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x63,\"type\":2}]}",
+      "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x63,\"type\":2}]}",
+      "format": "R3",
+      "mask": "0xfe00707f",
+      "match": "0xc600002b"
     },
     {
       "order": 109,
@@ -1629,13 +1629,13 @@
       "category": "Permutation",
       "synopsis": "Row zip (interleave rows from two inputs)",
       "mnemonic": "mrowzip.ew md, ms1, ms2",
-      "description": "Interleaves rows from the logical source square at `ms1` and the logical\nsource square at `ms2` into the destination register pair (`md`, `md+1`).\n+\nLet `N = sqrt(AME_NELEM)`. For each row `k` in `[0, N)` and column `j`:\n+\nD[2k,   j] = A[k, j]\nD[2k+1, j] = B[k, j]\n+\nEach source is its sole square or packed slot 0.  `md` must be even-aligned.\nRows from `ms1` appear at even positions and rows from `ms2` appear at odd\npositions within the two-square logical destination.\n+\nThe datatype size must be no greater than `AME_UNIT_DATATYPE_SIZE`; a wider\ntuple is unsupported.  For a packed datatype, `D0` occupies slot 0 of `md`\nand `D1` occupies slot 0 of `md+1`; every other destination slot is\npreserved.\n+\nInverse of `mrowunzip.ew`.",
+      "description": "Interleaves rows from the logical source square at `ms1` and the logical\nsource square at `ms2` into the two destination operands `D0` and `D1`.\n+\nLet `N = sqrt(AME_NELEM)`. For each row `k` in `[0, N/2)` and column `j`:\n+\nD0[2k, j]     = A[k, j]\nD0[2k+1, j]   = B[k, j]\nD1[2k, j]     = A[N/2+k, j]\nD1[2k+1, j]   = B[N/2+k, j]\n+\nwhere `A` and `B` are the logical source squares at `ms1` and `ms2`.\nRows from `A` appear at even positions and rows from `B` appear at odd\npositions within the two-square logical destination.  Each source is its\nsole square.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.\n+\n`D0` is the logical square at `md`, and `D1` occupies the consecutive M\nregisters immediately following `D0`.  A datatype wider than\n`AME_UNIT_DATATYPE_SIZE` therefore spans multiple consecutive M registers per\ndestination operand.\n+\n`md` must be aligned to the combined register span of `D0` and `D1`\n(even-aligned when each destination operand occupies a single M register).\nInverse of `mrowunzip.ew`.",
+      "operation": "D0[2k,j] = A[k,j]\nD0[2k+1,j] = B[k,j]\nD1[2k,j] = A[N/2+k,j]\nD1[2k+1,j] = B[N/2+k,j]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x38,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x38,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x7000002b",
-      "operation": "D[2i,:] = A[i,:]\nD[2i+1,:] = B[i,:]"
+      "match": "0x7000002b"
     },
     {
       "order": 110,
@@ -1645,72 +1645,72 @@
       "synopsis": "Elementwise reciprocal square root",
       "mnemonic": "mrsqrt.ew md, ms1",
       "description": "Elementwise reciprocal square root of `ms1`, stored into `md`.\n+\nThis instruction is defined only for floating-point datatypes. If the datatype of\n`md` or `ms1` is not a supported floating-point type, `amestatus.UN` is set and no\nregister is written.\n+\nThe numerical precision of the result is implementation-defined.",
+      "operation": "D[i] = 1 / sqrt(A[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x12,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x12,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa320002b",
-      "operation": "D[i] = 1 / sqrt(A[i])"
+      "match": "0xa320002b"
     },
     {
       "order": 111,
-      "name": "mscatadd.col",
-      "anchor": "ame:doc:inst:mscatadd_col",
+      "name": "mrowscatadd.ew",
+      "anchor": "ame:doc:inst:mrowscatadd_ew",
       "category": "Permutation",
-      "synopsis": "Elementwise column scatter-add",
-      "mnemonic": "mscatadd.col md, ms1, ms2",
-      "description": "Elementwise column scatter-add: routes each element of `ms1` to a destination row\nin `md` determined by the corresponding index in `ms2`, and accumulates with addition.\n+\nFor each row `i` and column `j`:\n+\nmd[ms2[i,j], j] += ms1[i,j]\n+\n`md` is both a source and destination: elements at the target rows are read,\nthe contribution from `ms1` is added, and the result is written back.\n+\n`ms2` provides integer row indices in the range `[0, sqrt(AME_NELEM))`.\nMultiple elements may scatter to the same destination row; all contributions are accumulated.\nAn out-of-range index raises an `Illegal Instruction` exception.\n+\nFor the row scatter-add form, see `mscatadd.row`.\nFor the column scatter-max form, see `mscatmax.col`.",
+      "synopsis": "Elementwise row scatter-add",
+      "mnemonic": "mrowscatadd.ew md, ms1, ms2",
+      "description": "Elementwise row scatter-add: routes each element of `ms1` to a destination row\nin `md` determined by the corresponding index in `ms2`, and accumulates with addition.\n+\nFor each row `i` and column `j`:\n+\nmd[ms2[i,j], j] += ms1[i,j]\n+\n`md` is both a source and destination: elements at the target columns are read,\nthe contribution from `ms1` is added, and the result is written back.\n+\n`ms2` provides integer row indices in the range `[0, sqrt(AME_NELEM))`.\nMultiple elements may scatter to the same destination row; all contributions are accumulated.\nAn out-of-range index raises an `Illegal Instruction` exception.\n+\nFor the column scatter-add form, see `mcolscatadd.ew`.\nFor the row scatter-max form, see `mrowscatmax.ew`.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.",
+      "operation": "D[B[i,j], j] += A[i,j]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x39,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x39,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x7200002b",
-      "operation": "D[B[i,j], j] += A[i,j]"
+      "match": "0x7200002b"
     },
     {
       "order": 112,
-      "name": "mscatadd.row",
-      "anchor": "ame:doc:inst:mscatadd_row",
+      "name": "mcolscatadd.ew",
+      "anchor": "ame:doc:inst:mcolscatadd_ew",
       "category": "Permutation",
-      "synopsis": "Elementwise scatter-add",
-      "mnemonic": "mscatadd.row md, ms1, ms2",
-      "description": "Elementwise scatter-add: routes each element of `ms1` to a destination column\nin `md` determined by the corresponding index in `ms2`, and accumulates with addition.\n+\nFor each row `i` and column `j`:\n+\nmd[i, ms2[i,j]] += ms1[i,j]\n+\n`md` is both a source and destination: elements at the target columns are read,\nthe contribution from `ms1` is added, and the result is written back.\n+\n`ms2` provides integer column indices in the range `[0, sqrt(AME_NELEM))`.\nMultiple elements may scatter to the same destination column; all contributions are accumulated.\nAn out-of-range index raises an `Illegal Instruction` exception.\n+\nFor the row scatter-max form, see `mscatmax.row`.\nFor the column scatter-add form, see `mscatadd.col`.",
+      "synopsis": "Elementwise column scatter-add",
+      "mnemonic": "mcolscatadd.ew md, ms1, ms2",
+      "description": "Elementwise column scatter-add: routes each element of `ms1` to a destination column\nin `md` determined by the corresponding index in `ms2`, and accumulates with addition.\n+\nFor each row `i` and column `j`:\n+\nmd[i, ms2[i,j]] += ms1[i,j]\n+\n`md` is both a source and destination: elements at the target rows are read,\nthe contribution from `ms1` is added, and the result is written back.\n+\n`ms2` provides integer column indices in the range `[0, sqrt(AME_NELEM))`.\nMultiple elements may scatter to the same destination column; all contributions are accumulated.\nAn out-of-range index raises an `Illegal Instruction` exception.\n+\nFor the column scatter-max form, see `mcolscatmax.ew`.\nFor the row scatter-add form, see `mrowscatadd.ew`.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.",
+      "operation": "D[i, B[i,j]] += A[i,j]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x3a,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x3a,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x7400002b",
-      "operation": "D[i, B[i,j]] += A[i,j]"
+      "match": "0x7400002b"
     },
     {
       "order": 113,
-      "name": "mscatmax.col",
-      "anchor": "ame:doc:inst:mscatmax_col",
+      "name": "mrowscatmax.ew",
+      "anchor": "ame:doc:inst:mrowscatmax_ew",
       "category": "Permutation",
-      "synopsis": "Elementwise column scatter-max",
-      "mnemonic": "mscatmax.col md, ms1, ms2",
-      "description": "Elementwise column scatter-max: routes each element of `ms1` to a destination row\nin `md` determined by the corresponding index in `ms2`, and accumulates with maximum.\n+\nFor each row `i` and column `j`:\n+\nmd[ms2[i,j], j] = max(md[ms2[i,j], j], ms1[i,j])\n+\n`md` is both a source and destination: elements at the target rows are read,\nthe maximum with the incoming value is taken, and the result is written back.\n+\n`ms2` provides integer row indices in the range `[0, sqrt(AME_NELEM))`.\nMultiple elements may scatter to the same destination row; all contributions are reduced.\nAn out-of-range index raises an `Illegal Instruction` exception.\n+\nFor the row scatter-max form, see `mscatmax.row`.\nFor the column scatter-add form, see `mscatadd.col`.",
+      "synopsis": "Elementwise row scatter-max",
+      "mnemonic": "mrowscatmax.ew md, ms1, ms2",
+      "description": "Elementwise row scatter-max: routes each element of `ms1` to a destination row\nin `md` determined by the corresponding index in `ms2`, and accumulates with maximum.\n+\nFor each row `i` and column `j`:\n+\nmd[ms2[i,j], j] = max(md[ms2[i,j], j], ms1[i,j])\n+\n`md` is both a source and destination: elements at the target columns are read,\nthe maximum with the incoming value is taken, and the result is written back.\n+\n`ms2` provides integer row indices in the range `[0, sqrt(AME_NELEM))`.\nMultiple elements may scatter to the same destination row; all contributions are reduced.\nAn out-of-range index raises an `Illegal Instruction` exception.\n+\nFor the column scatter-max form, see `mcolscatmax.ew`.\nFor the row scatter-add form, see `mrowscatadd.ew`.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.",
+      "operation": "D[B[i,j], j] = max(D[B[i,j],j], A[i,j])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x3b,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x3b,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x7600002b",
-      "operation": "D[B[i,j], j] = max(D[B[i,j],j], A[i,j])"
+      "match": "0x7600002b"
     },
     {
       "order": 114,
-      "name": "mscatmax.row",
-      "anchor": "ame:doc:inst:mscatmax_row",
+      "name": "mcolscatmax.ew",
+      "anchor": "ame:doc:inst:mcolscatmax_ew",
       "category": "Permutation",
-      "synopsis": "Elementwise scatter-max",
-      "mnemonic": "mscatmax.row md, ms1, ms2",
-      "description": "Elementwise scatter-max: routes each element of `ms1` to a destination column\nin `md` determined by the corresponding index in `ms2`, and accumulates with maximum.\n+\nFor each row `i` and column `j`:\n+\nmd[i, ms2[i,j]] = max(md[i, ms2[i,j]], ms1[i,j])\n+\n`md` is both a source and destination: elements at the target columns are read,\nthe maximum with the incoming value is taken, and the result is written back.\n+\n`ms2` provides integer column indices in the range `[0, sqrt(AME_NELEM))`.\nMultiple elements may scatter to the same destination column; all contributions are reduced.\nAn out-of-range index raises an `Illegal Instruction` exception.\n+\nFor the row scatter-add form, see `mscatadd.row`.\nFor the column scatter-max form, see `mscatmax.col`.",
+      "synopsis": "Elementwise column scatter-max",
+      "mnemonic": "mcolscatmax.ew md, ms1, ms2",
+      "description": "Elementwise column scatter-max: routes each element of `ms1` to a destination column\nin `md` determined by the corresponding index in `ms2`, and accumulates with maximum.\n+\nFor each row `i` and column `j`:\n+\nmd[i, ms2[i,j]] = max(md[i, ms2[i,j]], ms1[i,j])\n+\n`md` is both a source and destination: elements at the target rows are read,\nthe maximum with the incoming value is taken, and the result is written back.\n+\n`ms2` provides integer column indices in the range `[0, sqrt(AME_NELEM))`.\nMultiple elements may scatter to the same destination column; all contributions are reduced.\nAn out-of-range index raises an `Illegal Instruction` exception.\n+\nFor the column scatter-add form, see `mcolscatadd.ew`.\nFor the row scatter-max form, see `mrowscatmax.ew`.\n+\nThe common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\ndatatypes are not supported.",
+      "operation": "D[i, B[i,j]] = max(D[i,B[i,j]], A[i,j])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x3c,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x3c,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x7800002b",
-      "operation": "D[i, B[i,j]] = max(D[i,B[i,j]], A[i,j])"
+      "match": "0x7800002b"
     },
     {
       "order": 115,
@@ -1720,12 +1720,12 @@
       "synopsis": "Elementwise predicated select (non-negative)",
       "mnemonic": "mselge.ew md, ms1, ms2",
       "description": "Elementwise predicated select using the non-negative sign of `ms1` to gate `ms2` into `md`.\n+\nFor each element, `md[i] = ms2[i]` if `ms1[i] >= 0` (sign bit clear),\notherwise `md[i] = 0`.\n+\n`ms1` serves as the predicate register: any non-negative value is treated as true.\nThis allows comparison results or arithmetic sign values to be used directly\nas predicates without normalization.\n+\nComplementary to `msellt.ew`.",
+      "operation": "D[i] = (A[i] >= 0) ? B[i] : 0",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x30,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x30,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x6000002b",
-      "operation": "D[i] = (A[i] >= 0) ? B[i] : 0"
+      "match": "0x6000002b"
     },
     {
       "order": 116,
@@ -1735,12 +1735,12 @@
       "synopsis": "Elementwise predicated select (negative)",
       "mnemonic": "msellt.ew md, ms1, ms2",
       "description": "Elementwise predicated select using the sign of `ms1` to gate `ms2` into `md`.\n+\nFor each element, `md[i] = ms2[i]` if `ms1[i] < 0` (sign bit set),\notherwise `md[i] = 0`.\n+\n`ms1` serves as the predicate register: any negative value is treated as true.\nThis allows comparison results or arithmetic sign values to be used directly\nas predicates without normalization.\n+\nComplementary to `mselge.ew`.",
+      "operation": "D[i] = (A[i] < 0) ? B[i] : 0",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x31,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x31,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x6200002b",
-      "operation": "D[i] = (A[i] < 0) ? B[i] : 0"
+      "match": "0x6200002b"
     },
     {
       "order": 117,
@@ -1750,12 +1750,12 @@
       "synopsis": "Set datatype",
       "mnemonic": "msettyp md, xs1",
       "description": "Sets `Md[md]` to the low 32 bits of `X[xs1]` and clears every physical storage bit\nin the complete M-register group required by that new datatype.  This is a\nraw-bit clear, not conversion to the new datatype's semantic zero.  The group\nbase must meet the new datatype's alignment requirement and its complete span\nmust fit in the implemented M register file.  Upper X-register bits are ignored.",
+      "operation": "new_dtype = X[xs1][31:0]\ngroup_size = max(1, ceil(sizeof(new_dtype) / AME_UNIT_DATATYPE_SIZE))\nMd[md] = new_dtype; raw_bits(M[md .. md+group_size-1]) = 0",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x3,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x3,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa230002b",
-      "operation": "new_dtype = X[xs1][31:0]\ngroup_size = max(1, ceil(sizeof(new_dtype) / AME_UNIT_DATATYPE_SIZE))\nMd[md] = new_dtype; raw_bits(M[md .. md+group_size-1]) = 0"
+      "match": "0xa230002b"
     },
     {
       "order": 118,
@@ -1765,12 +1765,12 @@
       "synopsis": "Elementwise sine",
       "mnemonic": "msin.ew md, ms1",
       "description": "Elementwise sine of `ms1`, stored into `md`.\n+\nThis instruction is defined only for floating-point datatypes. If the datatype of\n`md` or `ms1` is not a supported floating-point type, `amestatus.UN` is set and no\nregister is written.\n+\nThe numerical precision of the result is implementation-defined.",
+      "operation": "D[i] = sin(A[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x13,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x13,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa330002b",
-      "operation": "D[i] = sin(A[i])"
+      "match": "0xa330002b"
     },
     {
       "order": 119,
@@ -1780,12 +1780,12 @@
       "synopsis": "Elementwise logical left shift",
       "mnemonic": "msll.ew md, ms1, ms2",
       "description": "Elementwise logical left shift of `ms1` by the per-element shift amount in `ms2`, stored into `md`.\n+\nOnly the low `lg2(EW)` bits of each shift-amount value are used, where `EW` is the\nelement width in bits of `ms1`. Shift amounts are interpreted as unsigned bit patterns.",
+      "operation": "D[i] = A[i] << (B[i] mod EW)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x22,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x22,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x4400002b",
-      "operation": "D[i] = A[i] << (B[i] mod EW)"
+      "match": "0x4400002b"
     },
     {
       "order": 120,
@@ -1795,12 +1795,12 @@
       "synopsis": "Elementwise scalar logical left shift",
       "mnemonic": "msll.ew.x md, xs1, ms2",
       "description": "Logical left shift of every element of `ms2` by a scalar amount from integer register `xs1`, stored into `md`.\n+\nOnly the low `lg2(EW)` bits of the scalar shift amount are used, where `EW` is the\nelement width in bits of `ms2`. The shift amount is interpreted as an unsigned bit pattern.\nThe X operand is a fixed unsigned integer control value and does not read\n`CSR[ame_scalar_dtype]`.",
+      "operation": "D[i] = B[i] << (c mod EW)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x23,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x23,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x4600002b",
-      "operation": "D[i] = B[i] << (c mod EW)"
+      "match": "0x4600002b"
     },
     {
       "order": 121,
@@ -1810,12 +1810,12 @@
       "synopsis": "Elementwise square root",
       "mnemonic": "msqrt.ew md, ms1",
       "description": "Elementwise square root of `ms1`, stored into `md`.\n+\nThis instruction is defined only for floating-point datatypes. If the datatype of\n`md` or `ms1` is not a supported floating-point type, `amestatus.UN` is set and no\nregister is written.\n+\nThe result is correctly rounded according to the destination datatype's rounding mode.",
+      "operation": "D[i] = sqrt(A[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x14,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x14,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa340002b",
-      "operation": "D[i] = sqrt(A[i])"
+      "match": "0xa340002b"
     },
     {
       "order": 122,
@@ -1825,12 +1825,12 @@
       "synopsis": "Elementwise arithmetic right shift",
       "mnemonic": "msra.ew md, ms1, ms2",
       "description": "Elementwise arithmetic (sign-preserving) right shift of `ms1` by the per-element shift amount in `ms2`, stored into `md`.\n+\nOnly the low `lg2(EW)` bits of each shift-amount value are used, where `EW` is the\nelement width in bits of `ms1`. Shift amounts are interpreted as unsigned bit patterns.",
+      "operation": "D[i] = A[i] >>s (B[i] mod EW)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x24,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x24,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x4800002b",
-      "operation": "D[i] = A[i] >>s (B[i] mod EW)"
+      "match": "0x4800002b"
     },
     {
       "order": 123,
@@ -1840,12 +1840,12 @@
       "synopsis": "Elementwise scalar arithmetic right shift",
       "mnemonic": "msra.ew.x md, xs1, ms2",
       "description": "Arithmetic (sign-preserving) right shift of every element of `ms2` by a scalar amount from integer register `xs1`, stored into `md`.\n+\nOnly the low `lg2(EW)` bits of the scalar shift amount are used, where `EW` is the\nelement width in bits of `ms2`. The shift amount is interpreted as an unsigned bit pattern.\nThe X operand is a fixed unsigned integer control value and does not read\n`CSR[ame_scalar_dtype]`.",
+      "operation": "D[i] = B[i] >>s (c mod EW)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x25,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x25,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x4a00002b",
-      "operation": "D[i] = B[i] >>s (c mod EW)"
+      "match": "0x4a00002b"
     },
     {
       "order": 124,
@@ -1855,12 +1855,12 @@
       "synopsis": "Elementwise logical right shift",
       "mnemonic": "msrl.ew md, ms1, ms2",
       "description": "Elementwise logical (unsigned) right shift of `ms1` by the per-element shift amount in `ms2`, stored into `md`.\n+\nOnly the low `lg2(EW)` bits of each shift-amount value are used, where `EW` is the\nelement width in bits of `ms1`. Shift amounts are interpreted as unsigned bit patterns.",
+      "operation": "D[i] = A[i] >>u (B[i] mod EW)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x26,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x26,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x4c00002b",
-      "operation": "D[i] = A[i] >>u (B[i] mod EW)"
+      "match": "0x4c00002b"
     },
     {
       "order": 125,
@@ -1870,12 +1870,12 @@
       "synopsis": "Elementwise scalar logical right shift",
       "mnemonic": "msrl.ew.x md, xs1, ms2",
       "description": "Logical (unsigned) right shift of every element of `ms2` by a scalar amount from integer register `xs1`, stored into `md`.\n+\nOnly the low `lg2(EW)` bits of the scalar shift amount are used, where `EW` is the\nelement width in bits of `ms2`. The shift amount is interpreted as an unsigned bit pattern.\nThe X operand is a fixed unsigned integer control value and does not read\n`CSR[ame_scalar_dtype]`.",
+      "operation": "D[i] = B[i] >>u (c mod EW)",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x27,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x27,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x4e00002b",
-      "operation": "D[i] = B[i] >>u (c mod EW)"
+      "match": "0x4e00002b"
     },
     {
       "order": 126,
@@ -1885,12 +1885,12 @@
       "synopsis": "Store raw M register in implementation-defined format",
       "mnemonic": "mss ms1, xs1",
       "description": "Stores exactly one physical M register `ms1` into memory in the\nimplementation-defined register format.\n+\nThe data written to memory is in the same implementation-defined format used by the\nmatching load instruction (`mls`). No datatype conversion is performed, and\nthe datatype in `Md[ms1]` is not interpreted.  Packed sub-squares resident in\n`ms1` are transferred together, while a wide logical square requires one\n`mss` for each physical M register in its group.\n+\nFor portable interoperability with other implementations, use\n<<ame:doc:inst:mss_rm,mss.rm>> or <<ame:doc:inst:mss_cm,mss.cm>>.\n+\nThe transfer size is `AME_MATRIX_REGISTER_SIZE / 8` bytes.  The address must\nbe aligned to that size or 4KB, whichever is smaller. Otherwise, `mss` raises\na `Store/AMO Misaligned` exception.",
+      "operation": "mem[xs1] <= ms1",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x19,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x19,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa390002b",
-      "operation": "mem[xs1] <= ms1"
+      "match": "0xa390002b"
     },
     {
       "order": 127,
@@ -1900,12 +1900,12 @@
       "synopsis": "Store square to column-major format",
       "mnemonic": "mss.cm ms1, xs1",
       "description": "Stores a square from matrix register `ms1` into memory in column-major format.\n+\nThe datatype is determined from `Md[ms1]`. For compute datatypes\n(size >= `AME_UNIT_DATATYPE_SIZE`), one square is stored. For packed datatypes\n(size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`\nsquares are unpacked from the single M register and stored.\n+\nThe data is written contiguously in column-major order: within each sub-square,\ncolumn `j` immediately follows column `j-1` with no padding. All elements are stored\nunconditionally.\n+\nLet `total_bytes = ceil(pack_factor * AME_NELEM * sizeof(Md[ms1]) / 8)`.\nThe address must be aligned to `total_bytes` or 4KB, whichever is smaller.\nOtherwise, `mss.cm` raises a `Store/AMO Misaligned` exception.",
+      "operation": "mem[xs1] <= ms1",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x1a,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x1a,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa3a0002b",
-      "operation": "mem[xs1] <= ms1"
+      "match": "0xa3a0002b"
     },
     {
       "order": 128,
@@ -1915,12 +1915,12 @@
       "synopsis": "Store square to row-major format",
       "mnemonic": "mss.rm ms1, xs1",
       "description": "Stores a square from matrix register `ms1` into memory in row-major format.\n+\nThe datatype is determined from `Md[ms1]`. For compute datatypes\n(size >= `AME_UNIT_DATATYPE_SIZE`), one square is stored. For packed datatypes\n(size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`\nsquares are unpacked from the single M register and stored.\n+\nThe data is written contiguously in row-major order: within each sub-square,\nrow `i` immediately follows row `i-1` with no padding. All elements are stored\nunconditionally.\n+\nLet `total_bytes = ceil(pack_factor * AME_NELEM * sizeof(Md[ms1]) / 8)`.\nThe address must be aligned to `total_bytes` or 4KB, whichever is smaller.\nOtherwise, `mss.rm` raises a `Store/AMO Misaligned` exception.",
+      "operation": "mem[xs1] <= ms1",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x1b,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": 0x1b,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa3b0002b",
-      "operation": "mem[xs1] <= ms1"
+      "match": "0xa3b0002b"
     },
     {
       "order": 129,
@@ -1930,12 +1930,12 @@
       "synopsis": "Store square to strided memory format",
       "mnemonic": "mss.st ms1, (xs1), xs2",
       "description": "Stores a square from matrix register `ms1` into memory in strided format.\n+\nThe datatype is determined from `Md[ms1]`. For compute datatypes\n(size >= `AME_UNIT_DATATYPE_SIZE`), one square is stored. For packed datatypes\n(size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`\nsquares are unpacked from the single M register and stored.\n+\nThe strided store writes memory as a sequence of equally spaced segments.\nFor non-packed datatypes, there are `sqrt(AME_NELEM)` segments, one per row, each\ncontaining `sqrt(AME_NELEM)` contiguous elements.\nFor packed datatypes, there are still `sqrt(AME_NELEM)` segments, but each segment\ncontains `pack_factor * sqrt(AME_NELEM)` contiguous elements — `pack_factor` sub-squares\nplaced side by side horizontally within each row.\nConsecutive segments are separated by a byte stride supplied in integer register `xs2`.\n+\nLet `element_bytes = ceil(sizeof(Md[ms1]) / 8)`.  The address must be aligned\nto `element_bytes` or 4KB, whichever is smaller. Otherwise, `mss.st` raises a\n`Store/AMO Misaligned` exception.  Segment byte counts and sub-byte packing\nfollow the common memory rules.",
+      "operation": "mem[xs1, stride=xs2] <= ms1",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"xs2\",\"type\":4},{\"bits\":7,\"name\": 0x56,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"xs2\",\"type\":4},{\"bits\":7,\"name\": 0x56,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xac00002b",
-      "operation": "mem[xs1, stride=xs2] <= ms1"
+      "match": "0xac00002b"
     },
     {
       "order": 130,
@@ -1945,12 +1945,12 @@
       "synopsis": "Store square to transposed strided memory format",
       "mnemonic": "mss.tst ms1, (xs1), xs2",
       "description": "Stores a square from matrix register `ms1` into memory in transposed strided format.\n+\nThe datatype is determined from `Md[ms1]`. For compute datatypes\n(size >= `AME_UNIT_DATATYPE_SIZE`), one square is stored. For packed datatypes\n(size < `AME_UNIT_DATATYPE_SIZE`), `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`\nsquares are unpacked from the single M register and stored.\n+\nThe transposed strided store writes memory as a sequence of equally spaced segments,\none segment per column of the square. Each segment contains `sqrt(AME_NELEM)` contiguous\nelements, and consecutive segments are separated by a byte stride supplied in integer\nregister `xs2`. For packed datatypes, the total number of segments is\n`pack_factor * sqrt(AME_NELEM)` — one column per sub-square, stacked vertically.\nThe segment addresses and within-segment bit offsets are defined by the common\nmemory rules; this arrangement transposes each square during the transfer.\n+\nLet `element_bytes = ceil(sizeof(Md[ms1]) / 8)`.  The address must be aligned\nto `element_bytes` or 4KB, whichever is smaller. Otherwise, `mss.tst` raises a\n`Store/AMO Misaligned` exception.",
+      "operation": "mem[xs1, stride=xs2] <= ms1",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"xs2\",\"type\":4},{\"bits\":7,\"name\": 0x57,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"xs2\",\"type\":4},{\"bits\":7,\"name\": 0x57,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0xae00002b",
-      "operation": "mem[xs1, stride=xs2] <= ms1"
+      "match": "0xae00002b"
     },
     {
       "order": 131,
@@ -1960,12 +1960,12 @@
       "synopsis": "Elementwise subtraction",
       "mnemonic": "msub.ew md, ms1, ms2",
       "description": "Vector subtraction of the tensors in `ms1` and `ms2`, stored into `md`.",
+      "operation": "D[i] = B[i] - A[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x18,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x18,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x3000002b",
-      "operation": "D[i] = B[i] - A[i]"
+      "match": "0x3000002b"
     },
     {
       "order": 132,
@@ -1975,12 +1975,12 @@
       "synopsis": "Elementwise scalar subtraction",
       "mnemonic": "msub.ew.x md, xs1, ms2",
       "description": "Subtracts every element of square `ms2` from a scalar constant from integer register `xs1`,\nstored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = xs1 - ms2[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = c - B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x19,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x19,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x3200002b",
-      "operation": "D[i] = c - B[i]"
+      "match": "0x3200002b"
     },
     {
       "order": 133,
@@ -1990,12 +1990,12 @@
       "synopsis": "Elementwise bias minus log2",
       "mnemonic": "msublog2.ew md, ms1, ms2",
       "description": "Elementwise complementary biased base-2 logarithm: subtracts the base-2 logarithm\nof the absolute value of `ms1` from `ms2`, stored into `md`.\n+\nFor each element, `md[i] = ms2[i] - log2(|ms1[i]|)`.\n+\nUseful for biased-exponent arithmetic, where `ms2` holds the bias value.\nComplementary to `mlog2sub.ew`.",
+      "operation": "D[i] = B[i] - log2(abs(A[i]))",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x47,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x47,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x8e00002b",
-      "operation": "D[i] = B[i] - log2(abs(A[i]))"
+      "match": "0x8e00002b"
     },
     {
       "order": 134,
@@ -2005,12 +2005,12 @@
       "synopsis": "Elementwise scalar bias minus log2",
       "mnemonic": "msublog2.ew.x md, xs1, ms2",
       "description": "Subtracts the elementwise base-2 logarithm of the absolute value of every element of\nsquare `ms2` from a scalar constant from integer register `xs1`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before being used as the bias for every element position `i`:\n+\nmd[i] = xs1 - log2(|ms2[i]|)\n+\nUseful for biased-exponent arithmetic, where `xs1` holds the bias value.\nComplementary to `mlog2sub.ew.x`.\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = c - log2(abs(B[i]))",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x48,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x48,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x9000002b",
-      "operation": "D[i] = c - log2(abs(B[i]))"
+      "match": "0x9000002b"
     },
     {
       "order": 135,
@@ -2020,12 +2020,12 @@
       "synopsis": "Elementwise hyperbolic tangent",
       "mnemonic": "mtanh.ew md, ms1",
       "description": "Elementwise hyperbolic tangent of `ms1`, stored into `md`.\n+\nThis instruction is defined only for floating-point datatypes. If the datatype of\n`md` or `ms1` is not a supported floating-point type, `amestatus.UN` is set and no\nregister is written.\n+\nThe numerical precision of the result is implementation-defined.",
+      "operation": "D[i] = tanh(A[i])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x15,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r2-bank0-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": 0x15,\"type\":2},{\"bits\":7,\"name\": 0x51,\"type\":2}]}",
       "format": "R2",
       "mask": "0xfff0707f",
-      "match": "0xa350002b",
-      "operation": "D[i] = tanh(A[i])"
+      "match": "0xa350002b"
     },
     {
       "order": 136,
@@ -2035,12 +2035,12 @@
       "synopsis": "Unpack one sub-square from a packed M register",
       "mnemonic": "munpack.ew.x md, ms1, xs1",
       "description": "Extracts a single sub-square, selected by the index in integer register `xs1`, from the\npacked M register `ms1` and writes it to the non-packed M register group beginning at `md`, converting each\nelement from the packed datatype (`Md[ms1]`) to the non-packed datatype (`Md[md]`).\n+\n`Md[ms1]` must be a packed datatype and `Md[md]` a non-packed datatype; otherwise\n`amestatus.UN` is set and no register is written. The index must be less than\n`pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`; an out-of-range index raises an\n`Illegal Instruction` exception.\nThe index is a fixed U32 unsigned integer control operand (the low 32 bits of\n`X[xs1]`) and does not read\n`CSR[ame_scalar_dtype]`.\n+\nThis is the single-square form of the unpack (expand) direction of\n<<ame:doc:inst:mconv_ew,mconv.ew>>; use it to unpack one square at a time and limit the\nregister pressure of fully expanding a packed register.",
+      "operation": "D = convert(A[k])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x3e,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":7,\"name\": 0x3e,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x7c00002b",
-      "operation": "D = convert(A[k])"
+      "match": "0x7c00002b"
     },
     {
       "order": 137,
@@ -2050,12 +2050,12 @@
       "synopsis": "Elementwise bitwise XOR",
       "mnemonic": "mxor.ew md, ms1, ms2",
       "description": "Elementwise bitwise XOR of the tensors in `ms1` and `ms2`, stored into `md`.",
+      "operation": "D[i] = A[i] ^ B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x28,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"ms1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x28,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x5000002b",
-      "operation": "D[i] = A[i] ^ B[i]"
+      "match": "0x5000002b"
     },
     {
       "order": 138,
@@ -2065,12 +2065,12 @@
       "synopsis": "Elementwise scalar bitwise XOR",
       "mnemonic": "mxor.ew.x md, xs1, ms2",
       "description": "Computes the elementwise bitwise XOR of a scalar constant from integer register `xs1`\nwith every element of square `ms2`, stored into `md`.\n+\nThe type of the scalar is determined by `CSR[ame_scalar_dtype]`. The scalar is converted\nto the datatype of `ms2` before the operation and then applied to every element position `i`:\n+\nmd[i] = xs1 ^ ms2[i]\n+\nIf either `Md[md]` or `Md[ms2]` is uninitialized (zero), or the datatype combination\nis not supported, `amestatus.UN` is set and no register is written.",
+      "operation": "D[i] = c ^ B[i]",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x29,\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": \"xs1\",\"type\":4},{\"bits\":5,\"name\": \"ms2\",\"type\":4},{\"bits\":7,\"name\": 0x29,\"type\":2}]}",
       "format": "R3",
       "mask": "0xfe00707f",
-      "match": "0x5200002b",
-      "operation": "D[i] = c ^ B[i]"
+      "match": "0x5200002b"
     },
     {
       "order": 139,
@@ -2080,12 +2080,12 @@
       "synopsis": "Clear accumulator tile",
       "mnemonic": "mzero.2d.acc acc",
       "description": "Writes zero to every element of `acc`.\n+\nTypically used to initialize an accumulator before a matrix multiply sequence.",
+      "operation": "C[i] = zero(Ad[acc])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r1-bank-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"acc\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": 0x53,\"type\":2}]}",
       "format": "R1",
       "mask": "0xfffff07f",
-      "match": "0xa600002b",
-      "operation": "C[i] = zero(Ad[acc])"
+      "match": "0xa600002b"
     },
     {
       "order": 140,
@@ -2095,12 +2095,12 @@
       "synopsis": "Clear tensor register",
       "mnemonic": "mzero.2d.m md",
       "description": "Writes zero to every element of the M register group `md`.\n+\nTypically used to initialize a tensor register before an elementwise sequence.",
+      "operation": "D[i] = zero(Md[md])",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": 0x1,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r1-bank-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":5,\"name\": \"md\",\"type\":4},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0x1,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":7,\"name\": 0x53,\"type\":2}]}",
       "format": "R1",
       "mask": "0xfffff07f",
-      "match": "0xa600802b",
-      "operation": "D[i] = zero(Md[md])"
+      "match": "0xa600802b"
     },
     {
       "order": 141,
@@ -2110,12 +2110,12 @@
       "synopsis": "Order selected AME memory transfers before selected non-AME memory transfers",
       "mnemonic": "fence.ame sw, sr, pw, pr",
       "description": "Orders AME memory transfers selected by the predecessor bits (`pr`, `pw`) before\nnon-AME memory transfers selected by the successor bits (`sr`, `sw`):\n+\n--\n* `pr` (bit 10) — predecessor set includes AME loads (reads from memory into `M` registers).\n* `pw` (bit 9) — predecessor set includes AME stores (writes from `M` registers to memory).\n* `sr` (bit 8) — successor set includes non-AME loads (reads into X, F, or V register files).\n* `sw` (bit 7) — successor set includes non-AME stores (writes from X, F, or V register files).\n--\n+\nWhen all four bits are set (`fence.ame sw, sr, pw, pr`), all AME memory transfers are\nguaranteed to be globally visible before any subsequent non-AME memory transfer.\nClearing a bit excludes the corresponding transfer class from the ordering constraint.\nAt least one of `pr`/`pw` must be set, and at least one of `sr`/`sw` must be set;\notherwise the instruction executes as a NOP with no ordering effect.\n+\nThis instruction is the AME-to-non-AME ordering primitive described in\n<<ame-consistency-model>>. It does *not* order non-AME transfers before AME transfers;\nfor that direction, software must use the standard RISC-V `fence` instruction.\n+\n`fence.ame` has no source or destination register operands. The four fence bits\nare encoded in the `rd` field position (bits 11:7), following the R1 instruction format.",
+      "operation": "order AME predecessors selected by pr/pw before non-AME successors selected by sr/sw",
       "wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":1,\"name\": \"sw\",\"type\":4},{\"bits\":1,\"name\": \"sr\",\"type\":4},{\"bits\":1,\"name\": \"pw\",\"type\":4},{\"bits\":1,\"name\": \"pr\",\"type\":4},{\"bits\":1,\"name\": 0,\"type\":2},{\"bits\":3,\"name\": {ame-enc-funct3},\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0x2,\"type\":2},{\"bits\":7,\"name\": {ame-enc-r1-bank-funct7},\"type\":2}]}",
       "resolved_wavedrom": "{\"reg\":[{\"bits\":7,\"name\": 0x2b,\"type\":2},{\"bits\":1,\"name\": \"sw\",\"type\":4},{\"bits\":1,\"name\": \"sr\",\"type\":4},{\"bits\":1,\"name\": \"pw\",\"type\":4},{\"bits\":1,\"name\": \"pr\",\"type\":4},{\"bits\":1,\"name\": 0,\"type\":2},{\"bits\":3,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0x0,\"type\":2},{\"bits\":5,\"name\": 0x2,\"type\":2},{\"bits\":7,\"name\": 0x53,\"type\":2}]}",
       "format": "R1",
       "mask": "0xfffff87f",
-      "match": "0xa620002b",
-      "operation": "order AME predecessors selected by pr/pw before non-AME successors selected by sr/sw"
+      "match": "0xa620002b"
     }
   ],
   "prose_semantics_baseline": "reviewed traditional-vector-style cutover",
@@ -2143,8 +2143,8 @@
     "mcolgather.ew": "D[i,j] = A[i, B[i,j]]",
     "mcolid.ew": "D[i,j] = j",
     "mcolshift.ew.x": "D[i,j] = A[i, j+c]",
-    "mcolunzip.ew": "D[i,j] = A[i,2j] + D[i, N/2+j] = A[i,2j+1]",
-    "mcolzip.ew": "D[i,2j] = A[i,j] + D[i,2j+1] = A[i, N/2+j]",
+    "mcolunzip.ew": "D^0^[i,j] = A[i,2j] + D^0^[i, N/2+j] = B[i,2j] + D^1^[i,j] = A[i,2j+1] + D^1^[i, N/2+j] = B[i,2j+1]",
+    "mcolzip.ew": "D^0^[i,2j] = A[i,j] + D^0^[i,2j+1] = B[i,j] + D^1^[i,2j] = A[i, N/2+j] + D^1^[i,2j+1] = B[i, N/2+j]",
     "mconv.ew": "D = convert(A) over the formed logical operand",
     "mbcast.m.x": "D[i] = CONV1D(X[xs1], X[xtyp], Md[md])",
     "mcos.ew": "D[i] = cos(A[i])",
@@ -2227,13 +2227,13 @@
     "mrowgather.ew": "D[i,j] = A[B[i,j],j]",
     "mrowid.ew": "D[i,j] = i",
     "mrowshift.ew.x": "D[i,j] = A[i+c,j]",
-    "mrowunzip.ew": "D^0^[i,:] = A[2i,:] + D^1^[i,:] = A[2i+1,:]",
-    "mrowzip.ew": "D[2i,:] = A[i,:] + D[2i+1,:] = B[i,:]",
+    "mrowunzip.ew": "D^0^[k,j] = A[2k,j] + D^0^[k+N/2,j] = B[2k,j] + D^1^[k,j] = A[2k+1,j] + D^1^[k+N/2,j] = B[2k+1,j]",
+    "mrowzip.ew": "D^0^[2k,j] = A[k,j] + D^0^[2k+1,j] = B[k,j] + D^1^[2k,j] = A[N/2+k,j] + D^1^[2k+1,j] = B[N/2+k,j]",
     "mrsqrt.ew": "D[i] = 1 / sqrt(A[i])",
-    "mscatadd.col": "D[B[i,j], j] += A[i,j]",
-    "mscatadd.row": "D[i, B[i,j]] += A[i,j]",
-    "mscatmax.col": "D[B[i,j], j] = max(D[B[i,j],j], A[i,j])",
-    "mscatmax.row": "D[i, B[i,j]] = max(D[i,B[i,j]], A[i,j])",
+    "mrowscatadd.ew": "D[B[i,j], j] += A[i,j]",
+    "mcolscatadd.ew": "D[i, B[i,j]] += A[i,j]",
+    "mrowscatmax.ew": "D[B[i,j], j] = max(D[B[i,j],j], A[i,j])",
+    "mcolscatmax.ew": "D[i, B[i,j]] = max(D[i,B[i,j]], A[i,j])",
     "mselge.ew": "D[i] = (A[i] >= 0) ? B[i] : 0",
     "msellt.ew": "D[i] = (A[i] < 0) ? B[i] : 0",
     "msettyp": "new_dtype = X[xs1][31:0]; Md[md] = new_dtype; raw_bits(M[md .. md+group_size-1]) = 0",

--- a/scripts/check-instruction-descriptions.rb
+++ b/scripts/check-instruction-descriptions.rb
@@ -26,7 +26,7 @@ baseline_path = File.join(root, "ref", "ame-instruction-baseline.json")
 audit_path = File.join(root, "docs", "migration", "ame-prose-migration-audit.md")
 errors = []
 
-expected_baseline_hash = "212c854c6fc143674ea84fd94584d14212d3d2f582a3f97723b31be4abae488b"
+expected_baseline_hash = "8a7169a803fc2b4618d1d8ef9f652d0b0d02ae51fe590cd11790bfd45bee6072"
 actual_baseline_hash = Digest::SHA256.file(baseline_path).hexdigest
 unless actual_baseline_hash == expected_baseline_hash
   errors << "baseline snapshot hash is #{actual_baseline_hash}, expected #{expected_baseline_hash}"
@@ -227,9 +227,9 @@ end
 {
   /data-source element width/ => "source-width shift rule",
   /scalar\s+datatype is wider than XLEN, the X-register bit pattern is zero-extended/m => "data-scalar widening rule",
-  /`mrowunzip\.ew` and `mrowzip\.ew` are also explicit fixed-shape exceptions/ => "row zip/unzip fixed-shape exception",
-  /family supports only datatypes whose size is\s+no greater than `AME_UNIT_DATATYPE_SIZE`/m => "row zip/unzip wide-type restriction",
-  /only slot 0 of each named register participates/ => "packed row zip/unzip slot selection",
+  /`mcolunzip\.ew`, `mcolzip\.ew`, `mrowunzip\.ew`, and\s+`mrowzip\.ew` are also\s+explicit fixed-shape exceptions/m => "zip/unzip fixed-shape exception",
+  /`D1`\s+occupies the\s+consecutive\s+M\s+registers immediately following `D0`/m => "zip/unzip consecutive destination-operand placement",
+  /The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed\s+datatypes are not supported/m => "Permutation unit-or-wide datatype rule",
   /The opaque `mls` and `mss` instructions do not inspect `Md`/ => "opaque load/store datatype exemption",
   /Elements are packed\s+back-to-back as E-bit fields/m => "typed memory bit packing",
   /load ignores the unused high bits.*store writes those unused high bits as zero/m => "partial-byte load/store rule",
@@ -246,8 +246,8 @@ end
   /derived accumulator span.*checked after the operation\s+tuple is supported/m => "packed accumulator span validation",
   /zero-extended or low-bit truncated/ => "fixed scalar-exponent width rule",
   /`mmulacc\.ew\.x`/ => "destination-as-source scalar fused-operation rule",
-  /`mscatadd\.col`, `mscatadd\.row`/ => "scatter-add floating-point rule",
-  /`mscatmax\.col`, `mscatmax\.row`/ => "scatter-max floating-point rule",
+  /`mcolscatadd\.ew`, `mrowscatadd\.ew`/ => "scatter-add floating-point rule",
+  /`mcolscatmax\.ew`, `mrowscatmax\.ew`/ => "scatter-max floating-point rule",
   /Scatter source elements are processed in ascending logical row-major order/ => "scatter collision ordering rule",
   /prefix or reduction fold is seeded from the first source element/ => "prefix/reduction seed rule",
   /transposes each `N x N` logical square/ => "dimensionally valid transposed matrix formation",
@@ -500,6 +500,14 @@ File.foreach(legacy_instructions_path).with_index(1) do |line, line_number|
   match = line.match(/^\[#(ame:doc:inst:[^\]]+)\]$/)
   legacy_instruction_lines[match[1]] = line_number.to_s if match
 end
+# Prose anchors renamed after the archive freeze keep their provenance through
+# the frozen legacy anchor.
+renamed_legacy_anchors = {
+  "ame:doc:inst:mcolscatadd_ew" => "ame:doc:inst:mscatadd_row",
+  "ame:doc:inst:mrowscatadd_ew" => "ame:doc:inst:mscatadd_col",
+  "ame:doc:inst:mcolscatmax_ew" => "ame:doc:inst:mscatmax_row",
+  "ame:doc:inst:mrowscatmax_ew" => "ame:doc:inst:mscatmax_col"
+}
 correction_expectations.each do |name, correction|
   row = audited_instruction_rows[name]
   baseline_entry = baseline.find { |entry| entry.fetch("name") == name }
@@ -507,7 +515,7 @@ correction_expectations.each do |name, correction|
 
   expected_contract = name == "fence.ame" ? "ame-common-ordering" : primary_contract[baseline_entry.fetch("category")]
   {
-    "legacy_line" => legacy_instruction_lines[baseline_entry.fetch("anchor")],
+    "legacy_line" => legacy_instruction_lines[renamed_legacy_anchors.fetch(baseline_entry.fetch("anchor"), baseline_entry.fetch("anchor"))],
     "anchor" => baseline_entry.fetch("anchor"),
     "category" => baseline_entry.fetch("category"),
     "mnemonic" => baseline_entry.fetch("mnemonic"),

--- a/scripts/check-instruction-encodings.rb
+++ b/scripts/check-instruction-encodings.rb
@@ -134,7 +134,7 @@ reserved_funct7 = {
   "Fixed" => []
 }
 expected_funct7 = {
-  "R3" => ((0x00..0x50).to_a + (0x54..0x60).to_a) - reserved_funct7.fetch("R3"),
+  "R3" => ((0x00..0x50).to_a + (0x54..0x63).to_a) - reserved_funct7.fetch("R3"),
   "R2" => [0x51, 0x52],
   "R1" => [0x53],
   "Fixed" => [0x52]
@@ -203,7 +203,7 @@ end
 # funct7 bank.  This turns the space-saving policy into a checked invariant
 # rather than a documentation preference.
 reserved_extensions = {
-  ["R2", 0x51] => [9],
+  ["R2", 0x51] => [9, 10, 11, 12],
   ["R2", 0x52] => [10],
   ["R1", 0x53] => (4..63).to_a
 }

--- a/src/datatypes.adoc
+++ b/src/datatypes.adoc
@@ -236,7 +236,8 @@ See <<operand-formation>> in the programming model for the complete rules and a 
 
 Because a packed M register holds multiple squares, packed formats increase register
 pressure when combined with wide datatypes — for example, in kernels such as flash
-attention. Explicit pack/unpack instructions (see <<ame:doc:inst:mconv_ew,mconv.ew>>)
+attention. Explicit pack/unpack instructions (see <<ame:doc:inst:mconv_ew,mconv.ew>>,
+<<ame:doc:inst:mpack_ew_x,mpack.ew.x>>, and <<ame:doc:inst:munpack_ew_x,munpack.ew.x>>)
 therefore remain necessary to convert between packed and non-packed layouts and to manage
 that pressure.
 

--- a/src/instruction-encoding-allocations.adoc
+++ b/src/instruction-encoding-allocations.adoc
@@ -44,11 +44,11 @@ selector is reserved. This does not define an additional register format.
 |===
 | Allocation | Instruction count | `funct7` allocation | Selector / fixed fields | Remaining capacity
 
-| R3 | 94 | `0x00..0x50`, `0x54..0x60` | n/a | 0 reserved values
-| R2 bank 0 | 31 | `{ame-enc-r2-bank0-funct7}` | `xfunct5=0..31` except `0x09` | 1 reserved value
+| R3 | 97 | `0x00..0x50`, `0x54..0x63` | n/a | 0 reserved values
+| R2 bank 0 | 28 | `{ame-enc-r2-bank0-funct7}` | `xfunct5=0..31` except `0x09..0x0C` | 4 reserved values
 | R2 bank 1 | 11 | `{ame-enc-r2-bank1-funct7}` | `xfunct5=0..0x0A`; `0x0A` fixes `rs1=rd=0` | 21
 | R1 | 5 | `{ame-enc-r1-bank-funct7}` | `xfunct10=0..3,64..79` | 959
-| Unallocated | 0 | `0x61..0x7f` | n/a | 31 `funct7` banks
+| Unallocated | 0 | `0x64..0x7f` | n/a | 28 `funct7` banks
 |===
 
 Within each register format, operation numbers follow the order of the encoded

--- a/src/instructions.adoc
+++ b/src/instructions.adoc
@@ -198,31 +198,31 @@ Permutation::
 a| `mcolbcast.ew.x md, ms1, xs1`
 | <<ame:doc:inst:mcolbcast_ew_x,Broadcast one column to all columns>>
 a| `mcolgather.ew md, ms1, ms2`
-| <<ame:doc:inst:mcolgather_ew,Elementwise gather (take)>>
+| <<ame:doc:inst:mcolgather_ew,Elementwise column gather (take)>>
+a| `mcolscatadd.ew md, ms1, ms2`
+| <<ame:doc:inst:mcolscatadd_ew,Elementwise column scatter-add>>
+a| `mcolscatmax.ew md, ms1, ms2`
+| <<ame:doc:inst:mcolscatmax_ew,Elementwise column scatter-max>>
 a| `mcolshift.ew.x md, ms1, xs1`
 | <<ame:doc:inst:mcolshift_ew_x,Elementwise column shift by scalar offset>>
-a| `mcolunzip.ew md, ms1`
-| <<ame:doc:inst:mcolunzip_ew,Elementwise column unzip (de-interleave)>>
-a| `mcolzip.ew md, ms1`
-| <<ame:doc:inst:mcolzip_ew,Elementwise column zip (interleave)>>
+a| `mcolunzip.ew md, ms1, ms2`
+| <<ame:doc:inst:mcolunzip_ew,Column unzip (de-interleave columns from two inputs)>>
+a| `mcolzip.ew md, ms1, ms2`
+| <<ame:doc:inst:mcolzip_ew,Column zip (interleave columns from two inputs)>>
 a| `mrowbcast.ew.x md, ms1, xs1`
 | <<ame:doc:inst:mrowbcast_ew_x,Broadcast one row to all rows>>
 a| `mrowgather.ew md, ms1, ms2`
 | <<ame:doc:inst:mrowgather_ew,Elementwise row gather (take)>>
+a| `mrowscatadd.ew md, ms1, ms2`
+| <<ame:doc:inst:mrowscatadd_ew,Elementwise row scatter-add>>
+a| `mrowscatmax.ew md, ms1, ms2`
+| <<ame:doc:inst:mrowscatmax_ew,Elementwise row scatter-max>>
 a| `mrowshift.ew.x md, ms1, xs1`
 | <<ame:doc:inst:mrowshift_ew_x,Elementwise row shift by scalar offset>>
-a| `mrowunzip.ew md, ms1`
-| <<ame:doc:inst:mrowunzip_ew,Row unzip (de-interleave rows)>>
+a| `mrowunzip.ew md, ms1, ms2`
+| <<ame:doc:inst:mrowunzip_ew,Row unzip (de-interleave rows from two inputs)>>
 a| `mrowzip.ew md, ms1, ms2`
 | <<ame:doc:inst:mrowzip_ew,Row zip (interleave rows from two inputs)>>
-a| `mscatadd.col md, ms1, ms2`
-| <<ame:doc:inst:mscatadd_col,Elementwise column scatter-add>>
-a| `mscatadd.row md, ms1, ms2`
-| <<ame:doc:inst:mscatadd_row,Elementwise scatter-add>>
-a| `mscatmax.col md, ms1, ms2`
-| <<ame:doc:inst:mscatmax_col,Elementwise column scatter-max>>
-a| `mscatmax.row md, ms1, ms2`
-| <<ame:doc:inst:mscatmax_row,Elementwise scatter-max>>
 !===
 
 Register move / data conversion::
@@ -1154,6 +1154,9 @@ If `c` is outside `[0, sqrt(AME_NELEM))`, an `Illegal Instruction` exception is 
 The `xs1` operand is a control scalar: its low 32 bits are interpreted as an
 unsigned integer column index.  It does not read `CSR[ame_scalar_dtype]` and does not undergo
 AME datatype conversion.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 
 Operation::
 +
@@ -1186,7 +1189,7 @@ This encoding is provisional and is not a final RISC-V allocation.
 ....
 
 Description::
-Elementwise gather: for each element in each row, uses the corresponding index from `ms2`
+Elementwise column gather: for each element in each row, uses the corresponding index from `ms2`
 to select a column from the same row of `ms1`, and stores the result into `md`.
 +
 For each row `i` and column `j`:
@@ -1195,6 +1198,9 @@ For each row `i` and column `j`:
 +
 `ms2` provides integer column indices in the range `[0, sqrt(AME_NELEM))`.
 An out-of-range index raises an `Illegal Instruction` exception.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 
 Operation::
 +
@@ -1288,6 +1294,9 @@ For each row `i` and column `j`:
 +
 Elements shifted beyond the row boundary are filled with zero (no wrap-around).
 For the row-shift form, see `mrowshift.ew.x`.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 
 Operation::
 +
@@ -1304,10 +1313,10 @@ This operation uses the common rules in <<ame-common-structural>>.
 === `mcolunzip.ew`
 
 Synopsis::
-Elementwise column unzip (de-interleave)
+Column unzip (de-interleave columns from two inputs)
 
 Mnemonic::
-`mcolunzip.ew md, ms1`
+`mcolunzip.ew md, ms1, ms2`
 
 Encoding::
 +
@@ -1316,26 +1325,45 @@ This encoding is provisional and is not a final RISC-V allocation.
 +
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x2b,"type":2},{"bits":5,"name": "md","type":4},{"bits":3,"name": {ame-enc-funct3},"type":2},{"bits":5,"name": "ms1","type":4},{"bits":5,"name": 0xa,"type":2},{"bits":7,"name": {ame-enc-r2-bank0-funct7},"type":2}]}
+{"reg":[{"bits":7,"name": 0x2b,"type":2},{"bits":5,"name": "md","type":4},{"bits":3,"name": {ame-enc-funct3},"type":2},{"bits":5,"name": "ms1","type":4},{"bits":5,"name": "ms2","type":4},{"bits":7,"name": 0x61,"type":2}]}
 ....
 
 Description::
-De-interleaves each row of `ms1` into lower and upper halves in `md`.
+De-interleaves the columns of the two-square logical source formed by the
+logical source square at `ms1` followed by the logical source square at `ms2`
+into the two destination operands `D0` and `D1`.
 +
 Let `N = sqrt(AME_NELEM)`. For each row `i` and index `j` in `[0, N/2)`:
 +
-  md[i, j]       = ms1[i, 2j]
-  md[i, j + N/2] = ms1[i, 2j+1]
+  D0[i, j]         = A[i, 2j]
+  D0[i, N/2 + j]   = B[i, 2j]
+  D1[i, j]         = A[i, 2j+1]
+  D1[i, N/2 + j]   = B[i, 2j+1]
 +
-Even-indexed columns of each row are collected into the lower half of the output;
-odd-indexed columns into the upper half.  Inverse of `mcolzip.ew`.
+where `A` and `B` are the logical source squares at `ms1` and `ms2`.
+Even-indexed columns of the logical source are collected into `D0`;
+odd-indexed columns into `D1`.  Each source is its sole square.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
++
+`D0` is the logical square at `md`, and `D1` occupies the consecutive M
+registers immediately following `D0`.  A datatype wider than
+`AME_UNIT_DATATYPE_SIZE` therefore spans multiple consecutive M registers per
+destination operand.
++
+`md` must be aligned to the combined register span of `D0` and `D1`
+(even-aligned when each destination operand occupies a single M register).
+Inverse of `mcolzip.ew`.
 
 Operation::
 +
 [source]
 ----
-D[i,j] = A[i,2j]
-D[i,N/2+j] = A[i,2j+1]
+D0[i,j] = A[i,2j]
+D0[i,N/2+j] = B[i,2j]
+D1[i,j] = A[i,2j+1]
+D1[i,N/2+j] = B[i,2j+1]
 ----
 +
 This operation uses the common rules in <<ame-common-structural>>.
@@ -1346,10 +1374,10 @@ This operation uses the common rules in <<ame-common-structural>>.
 === `mcolzip.ew`
 
 Synopsis::
-Elementwise column zip (interleave)
+Column zip (interleave columns from two inputs)
 
 Mnemonic::
-`mcolzip.ew md, ms1`
+`mcolzip.ew md, ms1, ms2`
 
 Encoding::
 +
@@ -1358,26 +1386,45 @@ This encoding is provisional and is not a final RISC-V allocation.
 +
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x2b,"type":2},{"bits":5,"name": "md","type":4},{"bits":3,"name": {ame-enc-funct3},"type":2},{"bits":5,"name": "ms1","type":4},{"bits":5,"name": 0xb,"type":2},{"bits":7,"name": {ame-enc-r2-bank0-funct7},"type":2}]}
+{"reg":[{"bits":7,"name": 0x2b,"type":2},{"bits":5,"name": "md","type":4},{"bits":3,"name": {ame-enc-funct3},"type":2},{"bits":5,"name": "ms1","type":4},{"bits":5,"name": "ms2","type":4},{"bits":7,"name": 0x62,"type":2}]}
 ....
 
 Description::
-Interleaves the lower and upper halves of each row of `ms1` into `md`.
+Interleaves columns from the logical source square at `ms1` and the logical
+source square at `ms2` into the two destination operands `D0` and `D1`.
 +
 Let `N = sqrt(AME_NELEM)`. For each row `i` and index `j` in `[0, N/2)`:
 +
-  md[i, 2j]   = ms1[i, j]
-  md[i, 2j+1] = ms1[i, j + N/2]
+  D0[i, 2j]     = A[i, j]
+  D0[i, 2j+1]   = B[i, j]
+  D1[i, 2j]     = A[i, N/2 + j]
+  D1[i, 2j+1]   = B[i, N/2 + j]
 +
-The lower half of each row occupies even columns in the output; the upper half
-occupies odd columns.  Inverse of `mcolunzip.ew`.
+where `A` and `B` are the logical source squares at `ms1` and `ms2`.
+Columns from `A` appear at even positions and columns from `B` appear at
+odd positions within the two-square logical destination.  Each source is its
+sole square.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
++
+`D0` is the logical square at `md`, and `D1` occupies the consecutive M
+registers immediately following `D0`.  A datatype wider than
+`AME_UNIT_DATATYPE_SIZE` therefore spans multiple consecutive M registers per
+destination operand.
++
+`md` must be aligned to the combined register span of `D0` and `D1`
+(even-aligned when each destination operand occupies a single M register).
+Inverse of `mcolunzip.ew`.
 
 Operation::
 +
 [source]
 ----
-D[i,2j] = A[i,j]
-D[i,2j+1] = A[i,N/2+j]
+D0[i,2j] = A[i,j]
+D0[i,2j+1] = B[i,j]
+D1[i,2j] = A[i,N/2+j]
+D1[i,2j+1] = B[i,N/2+j]
 ----
 +
 This operation uses the common rules in <<ame-common-structural>>.
@@ -1404,31 +1451,19 @@ This encoding is provisional and is not a final RISC-V allocation.
 ....
 
 Description::
-Converts element data between a packed datatype and a non-packed datatype.
+Converts element data between supported datatypes.
 +
 The source datatype is determined from `Md[ms1]` and the destination datatype from `Md[md]`.
-Exactly one of the two must be a packed datatype (size < `AME_UNIT_DATATYPE_SIZE`);
-if both or neither are packed, `mconv.ew` sets `amestatus.UN` and returns without
-modifying any register.
+The source and destination datatypes may each be a packed or a non-packed datatype; no
+particular packedness combination is required.  Both operands are formed by the common
+operand-formation rules, so the instruction's square count is `N_sq = max(pack_factor)`
+and every operand spans exactly `N_sq` squares.
 +
-**Expand (packed → non-packed):** When `Md[ms1]` is packed and `Md[md]` is a
-non-packed datatype, `ms1` holds `pack_factor = AME_UNIT_DATATYPE_SIZE / sizeof(Md[ms1])`
-packed squares. `mconv.ew` converts each element from the packed datatype to the non-packed
-datatype and writes `pack_factor` consecutive result-square groups.  If the
-destination square occupies `dst_group_size` registers, square `sq` begins at
-`md + sq * dst_group_size`.  The base must be aligned to `dst_group_size`, and
-the complete `pack_factor * dst_group_size` span must fit in the M register
-file; otherwise, `mconv.ew` raises an `Illegal Instruction` exception.
-+
-**Compress (non-packed → packed):** When `Md[ms1]` is a non-packed datatype and `Md[md]`
-is packed, `pack_factor` consecutive non-packed square groups begin at `ms1`.
-If each source square occupies `src_group_size` registers, square `sq` begins
-at `ms1 + sq * src_group_size`.
-`mconv.ew` converts each element from the non-packed datatype to the packed datatype and packs
-all `pack_factor` result squares into the single register `md`.
-The base must be aligned to `src_group_size`, and the complete
-`pack_factor * src_group_size` span must fit; otherwise, `mconv.ew` raises an
-`Illegal Instruction` exception.
+`mconv.ew` converts each element of the formed logical source operand from the source
+datatype to the destination datatype and writes the result squares to the formed logical
+destination operand.  A packed source with a non-packed destination therefore expands
+the source squares; a non-packed source with a packed destination compresses them; and
+operands with the same packedness convert each element without changing the square layout.
 +
 Element conversion follows the common datatype conversion rules; unsupported conversion tuples set
 `amestatus.UN` and do not modify any register.
@@ -4771,6 +4806,9 @@ If `c` is outside `[0, sqrt(AME_NELEM))`, an `Illegal Instruction` exception is 
 The `xs1` operand is a control scalar: its low 32 bits are interpreted as an
 unsigned integer row index.  It does not read `CSR[ame_scalar_dtype]` and does not undergo
 AME datatype conversion.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 
 Operation::
 +
@@ -4803,7 +4841,7 @@ This encoding is provisional and is not a final RISC-V allocation.
 ....
 
 Description::
-Elementwise gather: for each element in each column, uses the corresponding index from `ms2`
+Elementwise row gather: for each element in each column, uses the corresponding index from `ms2`
 to select a row from the same column of `ms1`, and stores the result into `md`.
 +
 For each row `i` and column `j`:
@@ -4812,6 +4850,9 @@ For each row `i` and column `j`:
 +
 `ms2` provides integer row indices in the range `[0, sqrt(AME_NELEM))`.
 An out-of-range index raises an `Illegal Instruction` exception.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 
 Operation::
 +
@@ -4893,15 +4934,21 @@ This encoding is provisional and is not a final RISC-V allocation.
 ....
 
 Description::
-Elementwise shift of each column of `ms1` by row offset `c`, obtained by
-interpreting the low 32 bits of integer register `xs1` as a signed
-two's-complement integer, stored into `md`.  This fixed-type control operand does not read
+Elementwise row shift of `ms1` by offset `c`, obtained by interpreting the
+low 32 bits of integer register `xs1` as a signed two's-complement integer,
+stored into `md`.  This fixed-type control operand does not read
 `CSR[ame_scalar_dtype]`.
 +
 For each row `i` and column `j`:
 +
   md[i,j] = ms1[i+c, j]  if 0 <= i+c < sqrt(AME_NELEM), otherwise
   md[i,j] = zero(Md[md]).
++
+Elements shifted beyond the column boundary are filled with zero (no wrap-around).
+For the column-shift form, see `mcolshift.ew.x`.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 
 Operation::
 +
@@ -4918,10 +4965,10 @@ This operation uses the common rules in <<ame-common-structural>>.
 === `mrowunzip.ew`
 
 Synopsis::
-Row unzip (de-interleave rows)
+Row unzip (de-interleave rows from two inputs)
 
 Mnemonic::
-`mrowunzip.ew md, ms1`
+`mrowunzip.ew md, ms1, ms2`
 
 Encoding::
 +
@@ -4930,32 +4977,45 @@ This encoding is provisional and is not a final RISC-V allocation.
 +
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x2b,"type":2},{"bits":5,"name": "md","type":4},{"bits":3,"name": {ame-enc-funct3},"type":2},{"bits":5,"name": "ms1","type":4},{"bits":5,"name": 0xc,"type":2},{"bits":7,"name": {ame-enc-r2-bank0-funct7},"type":2}]}
+{"reg":[{"bits":7,"name": 0x2b,"type":2},{"bits":5,"name": "md","type":4},{"bits":3,"name": {ame-enc-funct3},"type":2},{"bits":5,"name": "ms1","type":4},{"bits":5,"name": "ms2","type":4},{"bits":7,"name": 0x63,"type":2}]}
 ....
 
 Description::
-De-interleaves the rows of the source register pair (`ms1`, `ms1+1`) into the
-destination register pair (`md`, `md+1`).
+De-interleaves the rows of the two-square logical source formed by the logical
+source square at `ms1` followed by the logical source square at `ms2` into the
+two destination operands `D0` and `D1`.
 +
-Let `N = sqrt(AME_NELEM)`. For each row `k` in `[0, N)` and column `j`:
+Let `N = sqrt(AME_NELEM)`. For each row `k` in `[0, N/2)` and column `j`:
 +
-  D0[k, j] = A[2k,   j]   (even rows of the source)
-  D1[k, j] = A[2k+1, j]   (odd rows of the source)
+  D0[k, j]       = A[2k, j]
+  D0[k+N/2, j]   = B[2k, j]
+  D1[k, j]       = A[2k+1, j]
+  D1[k+N/2, j]   = B[2k+1, j]
 +
-The even-indexed rows are collected into logical destination square `D0` in
-`md`; the odd-indexed rows are collected into `D1` in `md+1`.  The datatype
-size must be no greater than `AME_UNIT_DATATYPE_SIZE`; a wider tuple is
-unsupported.  For a packed datatype, only slot 0 of each of `ms1`, `ms1+1`,
-`md`, and `md+1` participates, and every other destination slot is preserved.
+where `A` and `B` are the logical source squares at `ms1` and `ms2`.
+Even-indexed rows of the logical source are collected into `D0`; odd-indexed
+rows into `D1`.  Each source is its sole square.
 +
-`md` must be even-aligned.  Inverse of `mrowzip.ew`.
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
++
+`D0` is the logical square at `md`, and `D1` occupies the consecutive M
+registers immediately following `D0`.  A datatype wider than
+`AME_UNIT_DATATYPE_SIZE` therefore spans multiple consecutive M registers per
+destination operand.
++
+`md` must be aligned to the combined register span of `D0` and `D1`
+(even-aligned when each destination operand occupies a single M register).
+Inverse of `mrowzip.ew`.
 
 Operation::
 +
 [source]
 ----
-D0[i,:] = A[2i,:]
-D1[i,:] = A[2i+1,:]
+D0[k,j] = A[2k,j]
+D0[k+N/2,j] = B[2k,j]
+D1[k,j] = A[2k+1,j]
+D1[k+N/2,j] = B[2k+1,j]
 ----
 +
 This operation uses the common rules in <<ame-common-structural>>.
@@ -4983,30 +5043,40 @@ This encoding is provisional and is not a final RISC-V allocation.
 
 Description::
 Interleaves rows from the logical source square at `ms1` and the logical
-source square at `ms2` into the destination register pair (`md`, `md+1`).
+source square at `ms2` into the two destination operands `D0` and `D1`.
 +
-Let `N = sqrt(AME_NELEM)`. For each row `k` in `[0, N)` and column `j`:
+Let `N = sqrt(AME_NELEM)`. For each row `k` in `[0, N/2)` and column `j`:
 +
-  D[2k,   j] = A[k, j]
-  D[2k+1, j] = B[k, j]
+  D0[2k, j]     = A[k, j]
+  D0[2k+1, j]   = B[k, j]
+  D1[2k, j]     = A[N/2+k, j]
+  D1[2k+1, j]   = B[N/2+k, j]
 +
-Each source is its sole square or packed slot 0.  `md` must be even-aligned.
-Rows from `ms1` appear at even positions and rows from `ms2` appear at odd
-positions within the two-square logical destination.
+where `A` and `B` are the logical source squares at `ms1` and `ms2`.
+Rows from `A` appear at even positions and rows from `B` appear at odd
+positions within the two-square logical destination.  Each source is its
+sole square.
 +
-The datatype size must be no greater than `AME_UNIT_DATATYPE_SIZE`; a wider
-tuple is unsupported.  For a packed datatype, `D0` occupies slot 0 of `md`
-and `D1` occupies slot 0 of `md+1`; every other destination slot is
-preserved.
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 +
+`D0` is the logical square at `md`, and `D1` occupies the consecutive M
+registers immediately following `D0`.  A datatype wider than
+`AME_UNIT_DATATYPE_SIZE` therefore spans multiple consecutive M registers per
+destination operand.
++
+`md` must be aligned to the combined register span of `D0` and `D1`
+(even-aligned when each destination operand occupies a single M register).
 Inverse of `mrowunzip.ew`.
 
 Operation::
 +
 [source]
 ----
-D[2i,:] = A[i,:]
-D[2i+1,:] = B[i,:]
+D0[2k,j] = A[k,j]
+D0[2k+1,j] = B[k,j]
+D1[2k,j] = A[N/2+k,j]
+D1[2k+1,j] = B[N/2+k,j]
 ----
 +
 This operation uses the common rules in <<ame-common-structural>>.
@@ -5052,14 +5122,14 @@ This operation uses the common rules in <<ame-common-arithmetic>>.
 
 <<<
 
-[#ame:doc:inst:mscatadd_col]
-=== `mscatadd.col`
+[#ame:doc:inst:mrowscatadd_ew]
+=== `mrowscatadd.ew`
 
 Synopsis::
-Elementwise column scatter-add
+Elementwise row scatter-add
 
 Mnemonic::
-`mscatadd.col md, ms1, ms2`
+`mrowscatadd.ew md, ms1, ms2`
 
 Encoding::
 +
@@ -5072,22 +5142,25 @@ This encoding is provisional and is not a final RISC-V allocation.
 ....
 
 Description::
-Elementwise column scatter-add: routes each element of `ms1` to a destination row
+Elementwise row scatter-add: routes each element of `ms1` to a destination row
 in `md` determined by the corresponding index in `ms2`, and accumulates with addition.
 +
 For each row `i` and column `j`:
 +
   md[ms2[i,j], j] += ms1[i,j]
 +
-`md` is both a source and destination: elements at the target rows are read,
+`md` is both a source and destination: elements at the target columns are read,
 the contribution from `ms1` is added, and the result is written back.
 +
 `ms2` provides integer row indices in the range `[0, sqrt(AME_NELEM))`.
 Multiple elements may scatter to the same destination row; all contributions are accumulated.
 An out-of-range index raises an `Illegal Instruction` exception.
 +
-For the row scatter-add form, see `mscatadd.row`.
-For the column scatter-max form, see `mscatmax.col`.
+For the column scatter-add form, see `mcolscatadd.ew`.
+For the row scatter-max form, see `mrowscatmax.ew`.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 
 Operation::
 +
@@ -5100,14 +5173,14 @@ This operation uses the common rules in <<ame-common-structural>>.
 
 <<<
 
-[#ame:doc:inst:mscatadd_row]
-=== `mscatadd.row`
+[#ame:doc:inst:mcolscatadd_ew]
+=== `mcolscatadd.ew`
 
 Synopsis::
-Elementwise scatter-add
+Elementwise column scatter-add
 
 Mnemonic::
-`mscatadd.row md, ms1, ms2`
+`mcolscatadd.ew md, ms1, ms2`
 
 Encoding::
 +
@@ -5120,22 +5193,25 @@ This encoding is provisional and is not a final RISC-V allocation.
 ....
 
 Description::
-Elementwise scatter-add: routes each element of `ms1` to a destination column
+Elementwise column scatter-add: routes each element of `ms1` to a destination column
 in `md` determined by the corresponding index in `ms2`, and accumulates with addition.
 +
 For each row `i` and column `j`:
 +
   md[i, ms2[i,j]] += ms1[i,j]
 +
-`md` is both a source and destination: elements at the target columns are read,
+`md` is both a source and destination: elements at the target rows are read,
 the contribution from `ms1` is added, and the result is written back.
 +
 `ms2` provides integer column indices in the range `[0, sqrt(AME_NELEM))`.
 Multiple elements may scatter to the same destination column; all contributions are accumulated.
 An out-of-range index raises an `Illegal Instruction` exception.
 +
-For the row scatter-max form, see `mscatmax.row`.
-For the column scatter-add form, see `mscatadd.col`.
+For the column scatter-max form, see `mcolscatmax.ew`.
+For the row scatter-add form, see `mrowscatadd.ew`.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 
 Operation::
 +
@@ -5148,14 +5224,14 @@ This operation uses the common rules in <<ame-common-structural>>.
 
 <<<
 
-[#ame:doc:inst:mscatmax_col]
-=== `mscatmax.col`
+[#ame:doc:inst:mrowscatmax_ew]
+=== `mrowscatmax.ew`
 
 Synopsis::
-Elementwise column scatter-max
+Elementwise row scatter-max
 
 Mnemonic::
-`mscatmax.col md, ms1, ms2`
+`mrowscatmax.ew md, ms1, ms2`
 
 Encoding::
 +
@@ -5168,22 +5244,25 @@ This encoding is provisional and is not a final RISC-V allocation.
 ....
 
 Description::
-Elementwise column scatter-max: routes each element of `ms1` to a destination row
+Elementwise row scatter-max: routes each element of `ms1` to a destination row
 in `md` determined by the corresponding index in `ms2`, and accumulates with maximum.
 +
 For each row `i` and column `j`:
 +
   md[ms2[i,j], j] = max(md[ms2[i,j], j], ms1[i,j])
 +
-`md` is both a source and destination: elements at the target rows are read,
+`md` is both a source and destination: elements at the target columns are read,
 the maximum with the incoming value is taken, and the result is written back.
 +
 `ms2` provides integer row indices in the range `[0, sqrt(AME_NELEM))`.
 Multiple elements may scatter to the same destination row; all contributions are reduced.
 An out-of-range index raises an `Illegal Instruction` exception.
 +
-For the row scatter-max form, see `mscatmax.row`.
-For the column scatter-add form, see `mscatadd.col`.
+For the column scatter-max form, see `mcolscatmax.ew`.
+For the row scatter-add form, see `mrowscatadd.ew`.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 
 Operation::
 +
@@ -5196,14 +5275,14 @@ This operation uses the common rules in <<ame-common-structural>>.
 
 <<<
 
-[#ame:doc:inst:mscatmax_row]
-=== `mscatmax.row`
+[#ame:doc:inst:mcolscatmax_ew]
+=== `mcolscatmax.ew`
 
 Synopsis::
-Elementwise scatter-max
+Elementwise column scatter-max
 
 Mnemonic::
-`mscatmax.row md, ms1, ms2`
+`mcolscatmax.ew md, ms1, ms2`
 
 Encoding::
 +
@@ -5216,22 +5295,25 @@ This encoding is provisional and is not a final RISC-V allocation.
 ....
 
 Description::
-Elementwise scatter-max: routes each element of `ms1` to a destination column
+Elementwise column scatter-max: routes each element of `ms1` to a destination column
 in `md` determined by the corresponding index in `ms2`, and accumulates with maximum.
 +
 For each row `i` and column `j`:
 +
   md[i, ms2[i,j]] = max(md[i, ms2[i,j]], ms1[i,j])
 +
-`md` is both a source and destination: elements at the target columns are read,
+`md` is both a source and destination: elements at the target rows are read,
 the maximum with the incoming value is taken, and the result is written back.
 +
 `ms2` provides integer column indices in the range `[0, sqrt(AME_NELEM))`.
 Multiple elements may scatter to the same destination column; all contributions are reduced.
 An out-of-range index raises an `Illegal Instruction` exception.
 +
-For the row scatter-add form, see `mscatadd.row`.
-For the column scatter-max form, see `mscatmax.col`.
+For the column scatter-add form, see `mcolscatadd.ew`.
+For the row scatter-max form, see `mrowscatmax.ew`.
++
+The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 
 Operation::
 +

--- a/src/programming_model.adoc
+++ b/src/programming_model.adoc
@@ -273,30 +273,39 @@ non-packed operand's `N_sq` squares span `N_sq` registers.
 For 2D matrix multiply instructions, the inner product dimension extends to
 `N_sq * N` elements; see <<_2_dimensional_matrix_multiply_operations>>.
 
-The conversion-family instructions are explicit exceptions to this general
-multi-operand rule.  `mconv.ew` forms the complete expand or compress spans
-defined by that instruction, while `mpack.ew.x` and `munpack.ew.x` transfer one
-selected logical square and preserve or ignore the other packed slots as
-specified.  Their instruction-specific operand-formation rules take
-precedence over `N_sq = max(pack_factor)`.
+`mpack.ew.x` and `munpack.ew.x` are explicit exceptions to this general
+multi-operand rule.  They transfer one selected logical square and preserve or
+ignore the other packed slots as specified.  Their instruction-specific
+operand-formation rules take precedence over `N_sq = max(pack_factor)`.
+`mconv.ew`, by contrast, follows the general rule: its source and destination
+datatypes may each be packed or non-packed, and both operands span `N_sq`
+squares like any other elementwise instruction.
 
-`mrowunzip.ew` and `mrowzip.ew` are also explicit fixed-shape exceptions.
+`mcolunzip.ew`, `mcolzip.ew`, `mrowunzip.ew`, and `mrowzip.ew` are also
+explicit fixed-shape exceptions.
 They perform one two-square transformation rather than repeating a one-square
-transformation `N_sq` times.  This family supports only datatypes whose size is
-no greater than `AME_UNIT_DATATYPE_SIZE`; a wider tuple is unsupported and
-follows <<norm:ame_op_supported_contract>>.  Its two-square operands use the
-literal consecutive M-register bases named by the instruction.  For a unit
-datatype, each named register contains its sole square.  For a packed
-datatype, only slot 0 of each named register participates and every other
-destination slot is preserved.  `mrowunzip.ew` consumes (`ms1`, `ms1+1`) and
-produces (`md`, `md+1`); `mrowzip.ew` consumes slot 0 (or the sole square) from
-each of `ms1` and `ms2` and produces (`md`, `md+1`).  Every referenced physical
-register is validated before either destination square is written, and `md`
-must additionally be even-aligned as required by the instruction descriptions.
+transformation `N_sq` times.  Each instruction consumes the sole square from
+each of `ms1` and `ms2` and produces the two destination operands `D0` and
+`D1`.  `D0` is the logical square at `md`, and `D1` occupies the consecutive
+M registers immediately following `D0`, so the pair spans twice as many
+consecutive M registers starting at `md` as each operand requires (that is,
+two registers for a unit datatype, and twice
+`ceil(sizeof(Md[md]) / AME_UNIT_DATATYPE_SIZE)` for wider datatypes).  Every
+referenced physical register is validated before either destination square is
+written, and `md` must be aligned to the combined register span of `D0` and
+`D1`, as required by the instruction descriptions.
+
+All Permutation instructions -- the row/column broadcast, gather, scatter,
+and shift forms together with the fixed-shape zip/unzip forms -- support only
+datatypes whose size is no smaller than `AME_UNIT_DATATYPE_SIZE`; a packed
+datatype follows <<norm:ame_op_supported_contract>>.  The broadcast, gather,
+scatter, and shift operands therefore always form exactly one logical square
+(`N_sq = 1`).
 
 For `mcolgather.ew`, `mrowgather.ew`, and all four scatter instructions, the
 low 32 raw bits of each matrix-index element form an unsigned index; any higher
-element bits are ignored.  That U32 value must be less than
+element bits are ignored, and an element narrower than 32 bits is zero-extended
+to U32.  That U32 value must be less than
 `sqrt(AME_NELEM)`, or the instruction raises an Illegal Instruction exception.
 
 [#norm:ame_nsq_1d]#For an ordinary 1D element-wise instruction, the logical
@@ -305,14 +314,12 @@ logical elements of every operand over that entire range.# Instruction
 operation formulas that use a single element index apply over this complete
 range, including every packed or wide logical square.
 
-[#norm:ame_nsq_structural]#Except for the fixed two-square `mrowunzip.ew` and
-`mrowzip.ew` forms defined above, a row/column, gather/scatter, prefix, or
-reduction instruction applies its documented `N x N` transformation
-independently to each of the `N_sq` logical squares.# A row or column index is local to its
-square and cannot address another logical square.  A formula showing one
-`N x N` transformation therefore applies independently for
-`sq = 0 .. N_sq-1`, with logical element indices offset by
-`sq * AME_NELEM`.
+[#norm:ame_nsq_structural]#Prefix and reduction instructions apply their
+documented `N x N` transformation independently to each of the `N_sq` logical
+squares.# A row or column index is local to its square and cannot address
+another logical square.  A formula showing one `N x N` transformation
+therefore applies independently for `sq = 0 .. N_sq-1`, with logical element
+indices offset by `sq * AME_NELEM`.
 
 [#norm:ame_nsq_matmul]#For a 2D matrix multiply, let `A_s` and `B_s` denote
 logical square `s` of the two formed operands, for `s = 0 .. N_sq-1`.  Every
@@ -488,8 +495,12 @@ datatype.
 | Source and destination datatypes are identical; the operation is a bit-exact
 copy after the instruction-specific source selection and destination placement.
 
-| `mrowunzip.ew`, `mrowzip.ew` (additional fixed-pair restriction)
-| The common datatype size is no greater than `AME_UNIT_DATATYPE_SIZE`.
+| `mcolbcast.ew.x`, `mrowbcast.ew.x`, `mcolgather.ew`, `mrowgather.ew`,
+`mcolshift.ew.x`, `mrowshift.ew.x`, `mcolscatadd.ew`, `mrowscatadd.ew`,
+`mcolscatmax.ew`, `mrowscatmax.ew`, `mcolunzip.ew`, `mcolzip.ew`,
+`mrowunzip.ew`, `mrowzip.ew`
+| The common datatype size is no smaller than `AME_UNIT_DATATYPE_SIZE`; packed
+datatypes are not supported.
 
 | `mexp2.ew`, `mlog2.ew`, `mcos.ew`, `msin.ew`, `mtanh.ew`, `mrec.ew`,
 `mrsqrt.ew`, `msqrt.ew`, `mfrintm.ew`, `mfrintn.ew`, `mfrintp.ew`, `mfrintz.ew`
@@ -534,11 +545,11 @@ datatypes for that matrix operation.
 | `mprefixadd.col`, `mprefixadd.row`, `mreduceadd.col`, `mreduceadd.row`
 | Source and destination datatypes are identical numeric datatypes.
 
-| `mscatadd.col`, `mscatadd.row`
+| `mcolscatadd.ew`, `mrowscatadd.ew`
 | The contribution source is numeric, the matrix index source is integer, and
 the current destination value and result use the destination datatype.
 
-| `mscatmax.col`, `mscatmax.row`
+| `mcolscatmax.ew`, `mrowscatmax.ew`
 | The contribution source is ordered numeric, the matrix index source is
 integer, and the current destination value and result use the destination datatype.
 
@@ -1306,7 +1317,7 @@ Otherwise numerical ordering is used, with `+0` selected for a tie between
 | Exact selection of one operand.  Prefix and reduction instructions apply the
 binary operation in ascending source-element order.
 
-| `mscatmax.col`, `mscatmax.row`
+| `mcolscatmax.ew`, `mrowscatmax.ew`
 | A NaN operand produces the destination datatype's canonical quiet NaN.
 Operands are compared numerically after each is interpreted in its own
 datatype; a `-0`/`+0` tie produces `+0`.
@@ -1347,7 +1358,7 @@ sign; `mmulneg.ew` then negates that sign.
 rounded, but association order is implementation-defined and results may vary
 between implementations.
 
-| `mscatadd.col`, `mscatadd.row`
+| `mcolscatadd.ew`, `mrowscatadd.ew`
 | NaN and infinity behavior is the same as for `madd.ew`.
 | Each contribution is rounded to the destination datatype before the next
 contribution to the same destination; updates occur in ascending source order.
@@ -1501,7 +1512,9 @@ and maximum NaN and signed-zero behavior is also defined there.
 
 ==== Permutation operations
 
-AME permutation operations swizzle data within a single square.
+AME permutation operations swizzle data within logical squares.  The
+row/column broadcast, gather, scatter, and shift forms transform one square
+at a time, while the zip/unzip forms perform one two-square transformation.
 
 [cols="1,2,3",options="header"]
 |===
@@ -1509,49 +1522,57 @@ AME permutation operations swizzle data within a single square.
 | <<ame:doc:inst:mcolbcast_ew_x,mcolbcast.ew.x>>
 | `D[i,j] = A[i,c]`
 | Broadcast one selected column to all columns
-| <<ame:doc:inst:mcolunzip_ew,mcolunzip.ew>>
-| `D[i,j] = A[i,2j] +
- D[i, N/2+j] = A[i,2j+1]`
-| Elementwise column unzip (de-interleave)
-| <<ame:doc:inst:mcolzip_ew,mcolzip.ew>>
-| `D[i,2j] = A[i,j] +
- D[i,2j+1] = A[i, N/2+j]`
-| Elementwise column zip (interleave)
-| <<ame:doc:inst:mcolgather_ew,mcolgather.ew>>
-| `D[i,j] = A[i, B[i,j]]`
-| Elementwise gather (take)
-| <<ame:doc:inst:mrowunzip_ew,mrowunzip.ew>>
-| `D0[i,:] = A[2i,:] +
- D1[i,:] = A[2i+1,:]`
-| Row unzip (de-interleave rows)
-| <<ame:doc:inst:mrowzip_ew,mrowzip.ew>>
-| `D[2i,:] = A[i,:] +
- D[2i+1,:] = B[i,:]`
-| Row zip (interleave rows from two inputs)
-| <<ame:doc:inst:mscatadd_col,mscatadd.col>>
-| `D[B[i,j], j] += A[i,j]`
-| Elementwise column scatter-add
-| <<ame:doc:inst:mscatadd_row,mscatadd.row>>
-| `D[i, B[i,j]] += A[i,j]`
-| Elementwise scatter-add
-| <<ame:doc:inst:mscatmax_col,mscatmax.col>>
-| `D[B[i,j], j] = max(D[B[i,j],j], A[i,j])`
-| Elementwise column scatter-max
-| <<ame:doc:inst:mscatmax_row,mscatmax.row>>
-| `D[i, B[i,j]] = max(D[i,B[i,j]], A[i,j])`
-| Elementwise scatter-max
-| <<ame:doc:inst:mcolshift_ew_x,mcolshift.ew.x>>
-| `D[i,j] = A[i, j+c]`, with `zero(Md[md])` fill
-| Elementwise column shift by scalar offset
 | <<ame:doc:inst:mrowbcast_ew_x,mrowbcast.ew.x>>
 | `D[i,j] = A[c,j]`
 | Broadcast one selected row to all rows
+| <<ame:doc:inst:mcolgather_ew,mcolgather.ew>>
+| `D[i,j] = A[i, B[i,j]]`
+| Elementwise column gather (take)
 | <<ame:doc:inst:mrowgather_ew,mrowgather.ew>>
 | `D[i,j] = A[B[i,j],j]`
-| Elementwise row gather
+| Elementwise row gather (take)
+| <<ame:doc:inst:mcolscatadd_ew,mcolscatadd.ew>>
+| `D[i, B[i,j]] += A[i,j]`
+| Elementwise column scatter-add
+| <<ame:doc:inst:mrowscatadd_ew,mrowscatadd.ew>>
+| `D[B[i,j], j] += A[i,j]`
+| Elementwise row scatter-add
+| <<ame:doc:inst:mcolscatmax_ew,mcolscatmax.ew>>
+| `D[i, B[i,j]] = max(D[i,B[i,j]], A[i,j])`
+| Elementwise column scatter-max
+| <<ame:doc:inst:mrowscatmax_ew,mrowscatmax.ew>>
+| `D[B[i,j], j] = max(D[B[i,j],j], A[i,j])`
+| Elementwise row scatter-max
+| <<ame:doc:inst:mcolshift_ew_x,mcolshift.ew.x>>
+| `D[i,j] = A[i, j+c]`, with `zero(Md[md])` fill
+| Elementwise column shift by scalar offset
 | <<ame:doc:inst:mrowshift_ew_x,mrowshift.ew.x>>
 | `D[i,j] = A[i+c,j]`, with `zero(Md[md])` fill
 | Elementwise row shift by scalar offset
+| <<ame:doc:inst:mcolunzip_ew,mcolunzip.ew>>
+| `D0[i,j] = A[i,2j] +
+ D0[i, N/2+j] = B[i,2j] +
+ D1[i,j] = A[i,2j+1] +
+ D1[i, N/2+j] = B[i,2j+1]`
+| Column unzip (de-interleave columns from two inputs)
+| <<ame:doc:inst:mrowunzip_ew,mrowunzip.ew>>
+| `D0[i,:] = A[2i,:] +
+ D0[i+N/2,:] = B[2i,:] +
+ D1[i,:] = A[2i+1,:] +
+ D1[i+N/2,:] = B[2i+1,:]`
+| Row unzip (de-interleave rows from two inputs)
+| <<ame:doc:inst:mcolzip_ew,mcolzip.ew>>
+| `D0[i,2j] = A[i,j] +
+ D0[i,2j+1] = B[i,j] +
+ D1[i,2j] = A[i, N/2+j] +
+ D1[i,2j+1] = B[i, N/2+j]`
+| Column zip (interleave columns from two inputs)
+| <<ame:doc:inst:mrowzip_ew,mrowzip.ew>>
+| `D0[2i,:] = A[i,:] +
+ D0[2i+1,:] = B[i,:] +
+ D1[2i,:] = A[i+N/2,:] +
+ D1[2i+1,:] = B[i+N/2,:]`
+| Row zip (interleave rows from two inputs)
 |===
 
 Scatter source elements are processed in ascending logical row-major order.
@@ -1603,6 +1624,9 @@ index, represented in the configured datatype, to every logical element of an `M
 | <<ame:doc:inst:mcolid_ew,mcolid.ew>>
 | `D[i,j] = j`
 | Write the zero-based column index to every element
+| <<ame:doc:inst:mconv_ew,mconv.ew>>
+| `D[i] = convert(A[i])`
+| Convert element data between supported datatypes
 | <<ame:doc:inst:mpack_ew_x,mpack.ew.x>>
 | `D[k] = convert(A)`; preserve all `D[n]` for `n != k`
 | Convert and insert one non-packed square into packed slot `k = X[xs1]`
@@ -1612,8 +1636,10 @@ index, represented in the configured datatype, to every logical element of an `M
 |===
 
 `<<ame:doc:inst:mconv_ew,mconv.ew>>` converts element data from one datatype to another.
-An expand converts a single packed `M` register (packed dtype) into `pack_factor` consecutive
-non-packed `M` registers; a compress does the reverse.
+The source and destination datatypes may each be packed or non-packed, and both operands
+are formed by the common operand-formation rules with `N_sq = max(pack_factor)`.
+A packed-to-non-packed conversion expands one packed `M` register into `pack_factor` consecutive
+non-packed `M` registers; a non-packed-to-packed conversion does the reverse.
 The indexed <<ame:doc:inst:mpack_ew_x,mpack.ew.x>> and
 <<ame:doc:inst:munpack_ew_x,munpack.ew.x>> forms convert one selected square at a time,
 reducing register pressure when a full expand or compress is not required.


### PR DESCRIPTION
## Summary

- **zip/unzip destinations become matrix operands D0/D1**: `D0` is the logical square at `md`, `D1` occupies the consecutive M registers immediately following `D0`. Wide datatypes span multiple consecutive registers per operand; `md` aligns to the combined register span. This resolves the legacy `base`/`base+1` overlap contradiction for wide datatype tuples (audit AME-MIG-004).
- **All 14 Permutation instructions require datatypes no smaller than `AME_UNIT_DATATYPE_SIZE`**: packed datatypes follow the unsupported-operation contract. Broadcast/gather/scatter/shift operands therefore always form exactly one logical square (`N_sq = 1`).
- **`norm:ame_nsq_structural` narrowed** to prefix/reduction instructions, the only remaining forms that can form multiple packed logical squares.
- **Matrix-index elements narrower than 32 bits are zero-extended to U32** in the gather/scatter index formation rule (closes the sub-32-bit gap in the U32 raw-bits rule).
- **mconv.ew generalized** (prior commit): both source and destination may be packed or non-packed under the common `N_sq = max(pack_factor)` rule.
- **Encoding bookkeeping**: R3 funct7 allocation expanded to `0x54..0x63`, R2 bank 0 `xfunct5` `0x0A..0x0C` reserved; INSTRUCTION_ENCODINGS artifacts regenerated.

Synchronized layers: migration audit (AME-MIG-004), instruction baseline JSON, and the description checker hash.

## Verification

- `check-instruction-descriptions.rb`: 141/141 pages, 12/12 published normative anchors
- `check-instruction-encodings.rb`: R3=97 / R2=38 / R1=5 / Fixed=1, no overlaps
- `check-legacy-names.rb`: clean
- asciidoctor full-document render: 0 errors